### PR TITLE
Fix #1: Make optimistic-concurrency retry safe within the same scoped EventStore

### DIFF
--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -102,6 +102,9 @@ public sealed class EventStore : IEventStore
         // Events are 1-indexed; start from currentVersion + 1
         var version = currentVersion + 1;
 
+        // Track the entities we're about to add so we can clean them up if the append fails
+        var entitiesToAppend = new List<EventEntity>();
+
         foreach (var appendEvent in events)
         {
             // Validate that event aggregate matches stream type
@@ -143,6 +146,7 @@ public sealed class EventStore : IEventStore
             };
 
             _context.Events.Add(entity);
+            entitiesToAppend.Add(entity);
             version++;
         }
 
@@ -152,6 +156,14 @@ public sealed class EventStore : IEventStore
         }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
+            // Detach the failed entities from the context to prevent them from
+            // poisoning subsequent append attempts in the same scoped DbContext.
+            // This enables same-scope retry after catching StreamVersionConflictException.
+            foreach (var entity in entitiesToAppend)
+            {
+                _context.Entry(entity).State = EntityState.Detached;
+            }
+
             // Re-query to get the actual current version
             var actualVersion = await _context.Events
                 .Where(e => e.StreamType == expectedVersion.Stream.StreamType

--- a/Rickten.EventStore.Tests/Integration/ConcurrencyTests.cs
+++ b/Rickten.EventStore.Tests/Integration/ConcurrencyTests.cs
@@ -305,6 +305,103 @@ public class ConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public async Task SameScopeRetry_AfterOptimisticConcurrencyFailure_Succeeds()
+    {
+        // Regression test for GitHub issue #1:
+        // After a concurrency conflict, the same scoped EventStore should be able to
+        // reload the stream and successfully retry append without being poisoned by
+        // the failed entities from the first attempt.
+
+        var streamId = new StreamIdentifier("Account", "acc-same-scope-retry");
+
+        // Store 1 appends first event successfully
+        var store1 = CreateEventStore();
+        await store1.AppendAsync(
+            new StreamPointer(streamId, 0),
+            new List<AppendEvent> { new AppendEvent(new AccountDepositedEvent(100m), null) });
+
+        // Store 2 tries to append at stale version 0 - this should fail
+        var store2 = CreateEventStore();
+        var exception = await Assert.ThrowsAsync<StreamVersionConflictException>(async () =>
+        {
+            await store2.AppendAsync(
+                new StreamPointer(streamId, 0),
+                new List<AppendEvent> { new AppendEvent(new AccountDepositedEvent(200m), null) });
+        });
+
+        Assert.Equal(0, exception.ExpectedVersion.Version);
+        Assert.Equal(1, exception.ActualVersion.Version);
+
+        // Now retry with the SAME scoped store2 instance using the corrected version
+        // This should succeed - the failed append entities should not poison the context
+        var retryResult = await store2.AppendAsync(
+            new StreamPointer(streamId, exception.ActualVersion.Version),
+            new List<AppendEvent> { new AppendEvent(new AccountDepositedEvent(200m), null) });
+
+        Assert.Single(retryResult);
+        Assert.Equal(2, retryResult[0].StreamPointer.Version);
+
+        // Verify both events are now in the stream
+        var readStore = CreateEventStore();
+        var events = new List<StreamEvent>();
+        await foreach (var evt in readStore.LoadAsync(new StreamPointer(streamId, 0)))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Equal(2, events.Count);
+        Assert.Equal(1, events[0].StreamPointer.Version);
+        Assert.Equal(2, events[1].StreamPointer.Version);
+    }
+
+    [Fact]
+    public async Task SameScopeRetry_WithBatchAppend_AfterConflict_Succeeds()
+    {
+        // Test same-scope retry with multiple events in a batch
+        var streamId = new StreamIdentifier("Account", "acc-batch-retry");
+
+        // Store 1 appends first
+        var store1 = CreateEventStore();
+        await store1.AppendAsync(
+            new StreamPointer(streamId, 0),
+            new List<AppendEvent> { new AppendEvent(new AccountDepositedEvent(100m), null) });
+
+        // Store 2 tries to append batch at stale version - should fail
+        var store2 = CreateEventStore();
+        var batchEvents = new List<AppendEvent>
+        {
+            new AppendEvent(new AccountDepositedEvent(200m), null),
+            new AppendEvent(new AccountDepositedEvent(300m), null),
+            new AppendEvent(new AccountDepositedEvent(400m), null)
+        };
+
+        var exception = await Assert.ThrowsAsync<StreamVersionConflictException>(async () =>
+        {
+            await store2.AppendAsync(new StreamPointer(streamId, 0), batchEvents);
+        });
+
+        // Retry with same store2 using correct version
+        var retryResult = await store2.AppendAsync(
+            new StreamPointer(streamId, exception.ActualVersion.Version),
+            batchEvents);
+
+        Assert.Equal(3, retryResult.Count);
+        Assert.Equal(2, retryResult[0].StreamPointer.Version);
+        Assert.Equal(3, retryResult[1].StreamPointer.Version);
+        Assert.Equal(4, retryResult[2].StreamPointer.Version);
+
+        // Verify all 4 events are in the stream
+        var readStore = CreateEventStore();
+        var events = new List<StreamEvent>();
+        await foreach (var evt in readStore.LoadAsync(new StreamPointer(streamId, 0)))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Equal(4, events.Count);
+    }
+
+    [Fact]
     public async Task ConcurrentDifferentVersions_CorrectlyOrdered()
     {
         // Multiple clients appending at different (correct) versions should all succeed


### PR DESCRIPTION
## Summary

Fixes #1 

This PR fixes the EF-backed EventStore so an optimistic-concurrency conflict does not poison the current scoped DbContext/IEventStore. A caller can now catch StreamVersionConflictException, reload the stream, and retry append successfully using the same scoped IEventStore.

## Changes

### EventStore.cs
- Added tracking of entities during append attempts with a new `entitiesToAppend` list
- When a DbUpdateException with unique constraint violation occurs (optimistic concurrency conflict), the failed entities are now explicitly detached from the EF Core context using `EntityState.Detached`
- This cleanup prevents stale tracked entities from interfering with retry attempts using the same scoped IEventStore/DbContext

### ConcurrencyTests.cs
- Added `SameScopeRetry_AfterOptimisticConcurrencyFailure_Succeeds` test: Verifies that after a conflict, the same EventStore instance can reload the stream and retry successfully
- Added `SameScopeRetry_WithBatchAppend_AfterConflict_Succeeds` test: Tests the same scenario with batch appends (multiple events)

## Key Implementation Details

- **Targeted fix**: Only entities created during the failed append attempt are detached, not the entire context
- **Safe**: Only applies when a unique constraint violation is detected, preserving existing error handling
- **Minimal**: No breaking changes to the public API or existing behavior

## Testing

✅ All 178 tests pass (including new regression tests)  
✅ Tests run against SQLite, SQL Server (via Testcontainers), and PostgreSQL  
✅ Existing concurrency tests continue to pass, confirming no regression  
✅ New tests document the same-scope retry contract

## Acceptance Criteria

✅ Stale append still throws StreamVersionConflictException  
✅ Same scoped IEventStore can reload and retry after catching the exception  
✅ Stream contains only expected committed events  
✅ Existing concurrency behavior unchanged for successful appends  
✅ Tests document the same-scope retry contract