### PR TITLE
Bring DI setup docs and API reference in sync with assembly registration requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,21 +88,27 @@ dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 
 ### ⚠️ Type Registration Requirement
 
-The event store uses a **type metadata registry** built at startup for efficient type resolution without runtime assembly scanning. You must register assemblies containing your events, aggregates, and commands:
+**You must explicitly register assemblies** containing your events, aggregates, projections, commands, and reactions. The event store uses a **type metadata registry** built at startup for efficient type resolution without runtime assembly scanning.
 
 ```csharp
 // Register assemblies when configuring the event store
 services.AddEventStoreSqlServer(
     connectionString,
-    typeof(MyEvent).Assembly,        // Assembly with events
-    typeof(MyAggregate).Assembly);   // Assembly with aggregates (if different)
+    new[] { typeof(MyEvent).Assembly, typeof(MyAggregate).Assembly });
 
-// Or use AddEventStoreInMemory for testing
+// Or use a marker-type overload
+services.AddEventStoreSqlServer<MyEvent>(connectionString);
+
+// For testing with in-memory database
 services.AddEventStoreInMemory(
+    "TestDb",
     typeof(MyEvent).Assembly);
+
+// Or use marker-type overload for testing
+services.AddEventStoreInMemory<MyEvent>("TestDb");
 ```
 
-If you don't specify assemblies, only the calling assembly is registered by default.
+**Important:** If assemblies are not specified, the event store will throw an `ArgumentException`. There is no default or calling-assembly fallback.
 
 ## ⚡ Quick Start
 
@@ -351,13 +357,23 @@ var events = new[]
 Use this when all stores share the same database:
 
 ```csharp
-// In-memory (for testing)
-services.AddEventStoreInMemory("MyApp", typeof(MyEvent).Assembly);
+// In-memory (for testing) - must provide assemblies
+services.AddEventStoreInMemory(
+    "MyApp", 
+    typeof(MyEvent).Assembly);
 
-// SQL Server
-services.AddEventStoreSqlServer(connectionString, new[] { typeof(MyEvent).Assembly });
+// Or use marker-type overload
+services.AddEventStoreInMemory<MyEvent>("MyApp");
 
-// Custom configuration
+// SQL Server - must provide assemblies
+services.AddEventStoreSqlServer(
+    connectionString, 
+    new[] { typeof(MyEvent).Assembly });
+
+// Or use marker-type overload
+services.AddEventStoreSqlServer<MyEvent>(connectionString);
+
+// Custom configuration - must provide assemblies
 services.AddEventStore(options =>
 {
     options.UseSqlServer(connectionString, sqlOptions =>
@@ -369,6 +385,15 @@ services.AddEventStore(options =>
         sqlOptions.CommandTimeout(60);
     });
 }, typeof(MyEvent).Assembly, typeof(MyAggregate).Assembly);
+
+// Or use marker-type overload with custom configuration
+services.AddEventStore<MyEvent>(options =>
+{
+    options.UseSqlServer(connectionString, sqlOptions =>
+    {
+        sqlOptions.EnableRetryOnFailure();
+    });
+});
 ```
 
 ## 📝 Working with Events
@@ -897,6 +922,7 @@ dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
 ```
 
 ```csharp
+// Must provide assemblies
 services.AddEventStore(options =>
 {
     options.UseNpgsql(
@@ -906,6 +932,17 @@ services.AddEventStore(options =>
             npgsqlOptions.EnableRetryOnFailure(5);
         });
 }, typeof(MyEvent).Assembly);
+
+// Or use marker-type overload
+services.AddEventStore<MyEvent>(options =>
+{
+    options.UseNpgsql(
+        Configuration.GetConnectionString("EventStore"),
+        npgsqlOptions =>
+        {
+            npgsqlOptions.EnableRetryOnFailure(5);
+        });
+});
 ```
 
 ### SQLite
@@ -915,10 +952,17 @@ dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 ```
 
 ```csharp
+// Must provide assemblies
 services.AddEventStore(options =>
 {
     options.UseSqlite("Data Source=eventstore.db");
 }, typeof(MyEvent).Assembly);
+
+// Or use marker-type overload
+services.AddEventStore<MyEvent>(options =>
+{
+    options.UseSqlite("Data Source=eventstore.db");
+});
 ```
 
 ### Migrations
@@ -953,7 +997,12 @@ public class OrderServiceTests
     private IServiceProvider GetServiceProvider()
     {
         var services = new ServiceCollection();
-        services.AddEventStoreInMemory(Guid.NewGuid().ToString());
+        // Must provide assemblies containing events, aggregates, etc.
+        services.AddEventStoreInMemory(
+            Guid.NewGuid().ToString(),
+            typeof(OrderCreatedEvent).Assembly);
+        // Or use marker-type overload:
+        // services.AddEventStoreInMemory<OrderCreatedEvent>(Guid.NewGuid().ToString());
         services.AddScoped<OrderService>();
         return services.BuildServiceProvider();
     }
@@ -1034,7 +1083,12 @@ public class OrderIntegrationTests : IClassFixture<WebApplicationFactory<Program
                 if (descriptor != null)
                     services.Remove(descriptor);
 
-                services.AddEventStoreInMemory(Guid.NewGuid().ToString());
+                // Must provide assemblies for type registration
+                services.AddEventStoreInMemory(
+                    Guid.NewGuid().ToString(),
+                    typeof(OrderCreatedEvent).Assembly);
+                // Or use marker-type overload:
+                // services.AddEventStoreInMemory<OrderCreatedEvent>(Guid.NewGuid().ToString());
             });
         });
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -534,31 +534,196 @@ Extension methods for configuring Event Store services.
 
 Registers all stores (IEventStore, ISnapshotStore, IProjectionStore) with shared DbContext.
 
+**Primary Overload (Assembly Array):**
 ```csharp
 public static IServiceCollection AddEventStore(
+    this IServiceCollection services,
+    Action<DbContextOptionsBuilder> optionsAction,
+    params Assembly[] assemblies)
+```
+
+**Parameters:**
+- `services` (IServiceCollection): The service collection to add services to
+- `optionsAction` (Action<DbContextOptionsBuilder>): An action to configure the DbContext
+- `assemblies` (params Assembly[]): The assemblies containing events, aggregates, projections, commands, and reactions. **Required** - at least one assembly must be provided.
+
+**Throws:**
+- `ArgumentException`: When no assemblies are provided
+
+**Example:**
+```csharp
+services.AddEventStore(options =>
+{
+    options.UseSqlServer(connectionString);
+}, typeof(MyEvent).Assembly, typeof(MyAggregate).Assembly);
+```
+
+**Marker-Type Overloads:**
+
+Use a type from the assembly to scan:
+```csharp
+public static IServiceCollection AddEventStore<TMarker>(
     this IServiceCollection services,
     Action<DbContextOptionsBuilder> optionsAction)
 ```
 
+Use two types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStore<TMarker1, TMarker2>(
+    this IServiceCollection services,
+    Action<DbContextOptionsBuilder> optionsAction)
+```
+
+Use three types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStore<TMarker1, TMarker2, TMarker3>(
+    this IServiceCollection services,
+    Action<DbContextOptionsBuilder> optionsAction)
+```
+
+**Example:**
+```csharp
+// Single assembly using marker type
+services.AddEventStore<OrderCreatedEvent>(options =>
+{
+    options.UseSqlServer(connectionString);
+});
+
+// Multiple assemblies using marker types
+services.AddEventStore<OrderCreatedEvent, CustomerAggregate>(options =>
+{
+    options.UseSqlServer(connectionString);
+});
+
 #### AddEventStoreInMemory
 
-Registers all stores with in-memory database (testing).
+Registers all stores with in-memory database (for testing).
 
+**Primary Overload (Assembly Array):**
 ```csharp
 public static IServiceCollection AddEventStoreInMemory(
     this IServiceCollection services,
+    string databaseName,
+    params Assembly[] assemblies)
+```
+
+**Parameters:**
+- `services` (IServiceCollection): The service collection to add services to
+- `databaseName` (string): The name of the in-memory database
+- `assemblies` (params Assembly[]): The assemblies containing events, aggregates, projections, commands, and reactions. **Required** - at least one assembly must be provided.
+
+**Throws:**
+- `ArgumentException`: When no assemblies are provided
+
+**Example:**
+```csharp
+services.AddEventStoreInMemory(
+    "TestDb",
+    typeof(MyEvent).Assembly,
+    typeof(MyAggregate).Assembly);
+```
+
+**Marker-Type Overloads:**
+
+Use a type from the assembly to scan:
+```csharp
+public static IServiceCollection AddEventStoreInMemory<TMarker>(
+    this IServiceCollection services,
     string databaseName)
 ```
+
+Use two types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStoreInMemory<TMarker1, TMarker2>(
+    this IServiceCollection services,
+    string databaseName)
+```
+
+Use three types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStoreInMemory<TMarker1, TMarker2, TMarker3>(
+    this IServiceCollection services,
+    string databaseName)
+```
+
+**Example:**
+```csharp
+// Single assembly using marker type
+services.AddEventStoreInMemory<OrderCreatedEvent>("TestDb");
+
+// Multiple assemblies using marker types
+services.AddEventStoreInMemory<OrderCreatedEvent, CustomerAggregate>("TestDb");
 
 #### AddEventStoreSqlServer
 
 Registers all stores with SQL Server.
 
+**Primary Overload (Assembly Array):**
 ```csharp
 public static IServiceCollection AddEventStoreSqlServer(
     this IServiceCollection services,
-    string connectionString)
+    string connectionString,
+    Assembly[] assemblies,
+    Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
 ```
+
+**Parameters:**
+- `services` (IServiceCollection): The service collection to add services to
+- `connectionString` (string): The SQL Server connection string
+- `assemblies` (Assembly[]): The assemblies containing events, aggregates, projections, commands, and reactions. **Required** - at least one assembly must be provided.
+- `sqlServerOptionsAction` (Action<SqlServerDbContextOptionsBuilder>?): Optional SQL Server specific configuration (e.g., retry policies)
+
+**Throws:**
+- `ArgumentException`: When no assemblies are provided
+
+**Example:**
+```csharp
+services.AddEventStoreSqlServer(
+    connectionString,
+    new[] { typeof(MyEvent).Assembly, typeof(MyAggregate).Assembly },
+    sqlOptions =>
+    {
+        sqlOptions.EnableRetryOnFailure(5);
+        sqlOptions.CommandTimeout(60);
+    });
+```
+
+**Marker-Type Overloads:**
+
+Use a type from the assembly to scan:
+```csharp
+public static IServiceCollection AddEventStoreSqlServer<TMarker>(
+    this IServiceCollection services,
+    string connectionString,
+    Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+```
+
+Use two types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStoreSqlServer<TMarker1, TMarker2>(
+    this IServiceCollection services,
+    string connectionString,
+    Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+```
+
+Use three types from different assemblies:
+```csharp
+public static IServiceCollection AddEventStoreSqlServer<TMarker1, TMarker2, TMarker3>(
+    this IServiceCollection services,
+    string connectionString,
+    Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+```
+
+**Example:**
+```csharp
+// Single assembly using marker type
+services.AddEventStoreSqlServer<OrderCreatedEvent>(
+    connectionString,
+    sqlOptions => sqlOptions.EnableRetryOnFailure(5));
+
+// Multiple assemblies using marker types
+services.AddEventStoreSqlServer<OrderCreatedEvent, CustomerAggregate>(
+    connectionString);
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -594,6 +594,7 @@ services.AddEventStore<OrderCreatedEvent, CustomerAggregate>(options =>
 {
     options.UseSqlServer(connectionString);
 });
+```
 
 #### AddEventStoreInMemory
 
@@ -653,6 +654,7 @@ services.AddEventStoreInMemory<OrderCreatedEvent>("TestDb");
 
 // Multiple assemblies using marker types
 services.AddEventStoreInMemory<OrderCreatedEvent, CustomerAggregate>("TestDb");
+```
 
 #### AddEventStoreSqlServer
 
@@ -724,6 +726,7 @@ services.AddEventStoreSqlServer<OrderCreatedEvent>(
 // Multiple assemblies using marker types
 services.AddEventStoreSqlServer<OrderCreatedEvent, CustomerAggregate>(
     connectionString);
+```
 
 ---
 


### PR DESCRIPTION
Fixes #4

## Summary
Update documentation to align with the actual assembly registration requirement. The implementation requires callers to pass assemblies or use marker-type overloads, and throws ArgumentException when no assemblies are supplied.

## Changes Made

### README.md Updates:
- Removed misleading statement that calling assembly is registered by default
- Added explicit warning that assemblies MUST be provided or ArgumentException is thrown
- Updated all DI setup examples to show explicit assembly registration
- Added marker-type overload examples throughout
- Updated unit test and integration test examples to include assembly registration
- Updated PostgreSQL, SQLite, and SQL Server examples

### docs/API.md Updates:
- Updated AddEventStore signature to show required params Assembly[] parameter
- Updated AddEventStoreInMemory signature to show required params Assembly[] parameter
- Updated AddEventStoreSqlServer signature to show required Assembly[] parameter
- Documented all marker-type overloads
- Added examples showing both explicit assembly arrays and marker-type usage

## Verification
- No docs claim the calling assembly is auto-registered by default
- No public docs examples call AddEventStore methods without assemblies or marker types
- docs/API.md signatures match the public API shape
- README quick start and testing snippets are copy-pasteable with explicit type registration
- Build passes successfully