### PR TITLE
Fix #6: Clarify and harden metadata value typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,20 @@ var events = new[]
 // - EventMetadata("System", "StreamVersion", 1)
 ```
 
+**Accessing Metadata Values:**
+
+After storage, metadata values materialize as `JsonElement` due to JSON serialization. Use extension methods for safe access:
+
+```csharp
+// When reading metadata from loaded events
+var timestamp = streamEvent.Metadata.GetDateTime("Timestamp");
+var userId = streamEvent.Metadata.GetString("UserId");
+var correlationId = streamEvent.Metadata.GetGuid("CorrelationId");
+
+// Available: GetString, GetDateTime, GetGuid, GetInt32, GetInt64, 
+//            GetDecimal, GetDouble, GetBoolean
+```
+
 **Source Types:**
 - **"Client"** - Automatically assigned to all client-provided metadata
 - **"System"** - Automatically added by the event store (Timestamp, StreamVersion, etc.)

--- a/Rickten.EventStore.Tests/EventMetadataExtensionsTests.cs
+++ b/Rickten.EventStore.Tests/EventMetadataExtensionsTests.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+using Rickten.EventStore;
+
+namespace Rickten.EventStore.Tests;
+
+/// <summary>
+/// Tests for EventMetadataExtensions helper methods.
+/// </summary>
+public class EventMetadataExtensionsTests
+{
+    [Fact]
+    public void GetString_WithStringValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "UserId", "user-123")
+        };
+
+        var result = metadata.GetString("UserId");
+        Assert.Equal("user-123", result);
+    }
+
+    [Fact]
+    public void GetString_WithJsonElement_ReturnsValue()
+    {
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>("\"test-value\"");
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Key", jsonElement)
+        };
+
+        var result = metadata.GetString("Key");
+        Assert.Equal("test-value", result);
+    }
+
+    [Fact]
+    public void GetString_WithNullValue_ReturnsNull()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Key", null)
+        };
+
+        var result = metadata.GetString("Key");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetString_WithMissingKey_ReturnsNull()
+    {
+        var metadata = new List<EventMetadata>();
+        var result = metadata.GetString("MissingKey");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetDateTime_WithDateTimeValue_ReturnsValue()
+    {
+        var dateTime = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("System", "Timestamp", dateTime)
+        };
+
+        var result = metadata.GetDateTime("Timestamp");
+        Assert.Equal(dateTime, result);
+    }
+
+    [Fact]
+    public void GetDateTime_WithJsonElement_ReturnsValue()
+    {
+        var dateTime = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        var json = JsonSerializer.Serialize(dateTime);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("System", "Timestamp", jsonElement)
+        };
+
+        var result = metadata.GetDateTime("Timestamp");
+        Assert.NotNull(result);
+        Assert.Equal(dateTime, result.Value);
+    }
+
+    [Fact]
+    public void GetDateTime_WithNullValue_ReturnsNull()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("System", "Timestamp", null)
+        };
+
+        var result = metadata.GetDateTime("Timestamp");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetGuid_WithGuidValue_ReturnsValue()
+    {
+        var guid = Guid.NewGuid();
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "CorrelationId", guid)
+        };
+
+        var result = metadata.GetGuid("CorrelationId");
+        Assert.Equal(guid, result);
+    }
+
+    [Fact]
+    public void GetGuid_WithJsonElement_ReturnsValue()
+    {
+        var guid = Guid.NewGuid();
+        var json = JsonSerializer.Serialize(guid);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "CorrelationId", jsonElement)
+        };
+
+        var result = metadata.GetGuid("CorrelationId");
+        Assert.Equal(guid, result);
+    }
+
+    [Fact]
+    public void GetInt32_WithIntValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Count", 42)
+        };
+
+        var result = metadata.GetInt32("Count");
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void GetInt32_WithJsonElement_ReturnsValue()
+    {
+        var json = JsonSerializer.Serialize(42);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Count", jsonElement)
+        };
+
+        var result = metadata.GetInt32("Count");
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void GetInt64_WithLongValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "BigNumber", 1234567890L)
+        };
+
+        var result = metadata.GetInt64("BigNumber");
+        Assert.Equal(1234567890L, result);
+    }
+
+    [Fact]
+    public void GetInt64_WithJsonElement_ReturnsValue()
+    {
+        var json = JsonSerializer.Serialize(1234567890L);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "BigNumber", jsonElement)
+        };
+
+        var result = metadata.GetInt64("BigNumber");
+        Assert.Equal(1234567890L, result);
+    }
+
+    [Fact]
+    public void GetDecimal_WithDecimalValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Price", 99.99m)
+        };
+
+        var result = metadata.GetDecimal("Price");
+        Assert.Equal(99.99m, result);
+    }
+
+    [Fact]
+    public void GetDecimal_WithJsonElement_ReturnsValue()
+    {
+        var json = JsonSerializer.Serialize(99.99m);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Price", jsonElement)
+        };
+
+        var result = metadata.GetDecimal("Price");
+        Assert.Equal(99.99m, result);
+    }
+
+    [Fact]
+    public void GetDouble_WithDoubleValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Pi", 3.14159)
+        };
+
+        var result = metadata.GetDouble("Pi");
+        Assert.Equal(3.14159, result);
+    }
+
+    [Fact]
+    public void GetDouble_WithJsonElement_ReturnsValue()
+    {
+        var json = JsonSerializer.Serialize(3.14159);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "Pi", jsonElement)
+        };
+
+        var result = metadata.GetDouble("Pi");
+        Assert.Equal(3.14159, result);
+    }
+
+    [Fact]
+    public void GetBoolean_WithBoolValue_ReturnsValue()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "IsActive", true),
+            new EventMetadata("Client", "IsDeleted", false)
+        };
+
+        Assert.True(metadata.GetBoolean("IsActive"));
+        Assert.False(metadata.GetBoolean("IsDeleted"));
+    }
+
+    [Fact]
+    public void GetBoolean_WithJsonElement_ReturnsValue()
+    {
+        var jsonTrue = JsonSerializer.Deserialize<JsonElement>("true");
+        var jsonFalse = JsonSerializer.Deserialize<JsonElement>("false");
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "IsActive", jsonTrue),
+            new EventMetadata("Client", "IsDeleted", jsonFalse)
+        };
+
+        Assert.True(metadata.GetBoolean("IsActive"));
+        Assert.False(metadata.GetBoolean("IsDeleted"));
+    }
+
+    [Fact]
+    public void GetBoolean_WithNullValue_ReturnsNull()
+    {
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata("Client", "IsActive", null)
+        };
+
+        var result = metadata.GetBoolean("IsActive");
+        Assert.Null(result);
+    }
+}

--- a/Rickten.EventStore.Tests/MetadataValueTypingTests.cs
+++ b/Rickten.EventStore.Tests/MetadataValueTypingTests.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Rickten.EventStore;
+using Rickten.EventStore.EntityFramework;
+
+namespace Rickten.EventStore.Tests;
+
+/// <summary>
+/// Tests for metadata value typing behavior after round-trip through storage.
+/// EventMetadata.Value is object?, but after JSON serialization/deserialization,
+/// values materialize as JsonElement rather than their original CLR types.
+/// </summary>
+public class MetadataValueTypingTests
+{
+    private static EntityFramework.EventStore CreateStore(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<EventStoreDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        var context = new EventStoreDbContext(options);
+        var registry = TestTypeMetadataRegistry.Create();
+        return new EntityFramework.EventStore(context, registry);
+    }
+
+    private static StreamPointer MakePointer(string type, string id, long version)
+        => new StreamPointer(new StreamIdentifier(type, id), version);
+
+    [Fact]
+    public async Task Metadata_StringValue_RoundTrips()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "1", 0);
+
+        var stringValue = "test-value";
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[] { new AppendMetadata("StringKey", stringValue) })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "1", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata.First(m => m.Key == "StringKey");
+
+        // After round-trip through JSON, the value is a JsonElement
+        Assert.IsType<JsonElement>(metadata.Value);
+
+        // String values can be extracted from JsonElement
+        var jsonElement = (JsonElement)metadata.Value!;
+        Assert.Equal(JsonValueKind.String, jsonElement.ValueKind);
+        Assert.Equal(stringValue, jsonElement.GetString());
+    }
+
+    [Fact]
+    public async Task Metadata_DateTimeValue_BecomesJsonElement()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "2", 0);
+
+        var dateTimeValue = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[] { new AppendMetadata("CreatedDate", dateTimeValue) })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "2", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata.First(m => m.Key == "CreatedDate");
+
+        // After round-trip, DateTime becomes JsonElement
+        Assert.IsType<JsonElement>(metadata.Value);
+
+        // DateTime is serialized as ISO 8601 string
+        var jsonElement = (JsonElement)metadata.Value!;
+        Assert.Equal(JsonValueKind.String, jsonElement.ValueKind);
+
+        // Can parse back to DateTime
+        var parsedDateTime = jsonElement.GetDateTime();
+        Assert.Equal(dateTimeValue, parsedDateTime);
+    }
+
+    [Fact]
+    public async Task Metadata_GuidValue_BecomesJsonElement()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "3", 0);
+
+        var guidValue = Guid.NewGuid();
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[] { new AppendMetadata("CorrelationId", guidValue) })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "3", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata.First(m => m.Key == "CorrelationId");
+
+        // After round-trip, Guid becomes JsonElement
+        Assert.IsType<JsonElement>(metadata.Value);
+
+        // Guid is serialized as string
+        var jsonElement = (JsonElement)metadata.Value!;
+        Assert.Equal(JsonValueKind.String, jsonElement.ValueKind);
+
+        // Can parse back to Guid
+        var parsedGuid = jsonElement.GetGuid();
+        Assert.Equal(guidValue, parsedGuid);
+    }
+
+    [Fact]
+    public async Task Metadata_NumericValues_BecomeJsonElement()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "4", 0);
+
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[]
+                {
+                    new AppendMetadata("IntValue", 42),
+                    new AppendMetadata("LongValue", 1234567890L),
+                    new AppendMetadata("DoubleValue", 3.14159),
+                    new AppendMetadata("DecimalValue", 99.99m)
+                })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "4", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata;
+
+        // Int
+        var intMeta = metadata.First(m => m.Key == "IntValue");
+        Assert.IsType<JsonElement>(intMeta.Value);
+        var intElement = (JsonElement)intMeta.Value!;
+        Assert.Equal(JsonValueKind.Number, intElement.ValueKind);
+        Assert.Equal(42, intElement.GetInt32());
+
+        // Long
+        var longMeta = metadata.First(m => m.Key == "LongValue");
+        Assert.IsType<JsonElement>(longMeta.Value);
+        var longElement = (JsonElement)longMeta.Value!;
+        Assert.Equal(JsonValueKind.Number, longElement.ValueKind);
+        Assert.Equal(1234567890L, longElement.GetInt64());
+
+        // Double
+        var doubleMeta = metadata.First(m => m.Key == "DoubleValue");
+        Assert.IsType<JsonElement>(doubleMeta.Value);
+        var doubleElement = (JsonElement)doubleMeta.Value!;
+        Assert.Equal(JsonValueKind.Number, doubleElement.ValueKind);
+        Assert.Equal(3.14159, doubleElement.GetDouble(), precision: 5);
+
+        // Decimal
+        var decimalMeta = metadata.First(m => m.Key == "DecimalValue");
+        Assert.IsType<JsonElement>(decimalMeta.Value);
+        var decimalElement = (JsonElement)decimalMeta.Value!;
+        Assert.Equal(JsonValueKind.Number, decimalElement.ValueKind);
+        Assert.Equal(99.99m, decimalElement.GetDecimal());
+    }
+
+    [Fact]
+    public async Task Metadata_BooleanValue_BecomesJsonElement()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "5", 0);
+
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[]
+                {
+                    new AppendMetadata("IsActive", true),
+                    new AppendMetadata("IsDeleted", false)
+                })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "5", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata;
+
+        var trueMeta = metadata.First(m => m.Key == "IsActive");
+        Assert.IsType<JsonElement>(trueMeta.Value);
+        var trueElement = (JsonElement)trueMeta.Value!;
+        Assert.Equal(JsonValueKind.True, trueElement.ValueKind);
+        Assert.True(trueElement.GetBoolean());
+
+        var falseMeta = metadata.First(m => m.Key == "IsDeleted");
+        Assert.IsType<JsonElement>(falseMeta.Value);
+        var falseElement = (JsonElement)falseMeta.Value!;
+        Assert.Equal(JsonValueKind.False, falseElement.ValueKind);
+        Assert.False(falseElement.GetBoolean());
+    }
+
+    [Fact]
+    public async Task Metadata_NullValue_RoundTrips()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var store = CreateStore(dbName);
+        var pointer = MakePointer("Order", "6", 0);
+
+        var appendEvents = new List<AppendEvent>
+        {
+            new AppendEvent(
+                new OrderCreatedEvent(100),
+                new[] { new AppendMetadata("NullableKey", null) })
+        };
+
+        await store.AppendAsync(pointer, appendEvents);
+
+        var loaded = new List<StreamEvent>();
+        await foreach (var e in store.LoadAsync(MakePointer("Order", "6", 0)))
+            loaded.Add(e);
+
+        var metadata = loaded[0].Metadata.First(m => m.Key == "NullableKey");
+
+        // Null values remain null (they don't become JsonElement)
+        Assert.Null(metadata.Value);
+    }
+
+    [Fact]
+    public void Metadata_InvalidCast_ThrowsException()
+    {
+        // This test documents that casting to the original type DOES NOT WORK
+        var dateTimeValue = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+        var metadata = new EventMetadata("System", "Timestamp", dateTimeValue);
+
+        // Before serialization, the value is the original type
+        Assert.IsType<DateTime>(metadata.Value);
+
+        // After round-trip (simulated), the cast would fail:
+        var serialized = JsonSerializer.Serialize(new[] { metadata });
+        var deserialized = JsonSerializer.Deserialize<EventMetadata[]>(serialized);
+
+        var roundTripped = deserialized![0];
+
+        // This would throw InvalidCastException or return null
+        Assert.Throws<InvalidCastException>(() =>
+        {
+            var _ = (DateTime)roundTripped.Value!;
+        });
+
+        // Even "as" cast returns null instead of the value
+        var asDateTime = roundTripped.Value as DateTime?;
+        Assert.Null(asDateTime);
+
+        // The correct approach is to use JsonElement
+        Assert.IsType<JsonElement>(roundTripped.Value);
+    }
+}

--- a/Rickten.EventStore/EventMetadataExtensions.cs
+++ b/Rickten.EventStore/EventMetadataExtensions.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+
+namespace Rickten.EventStore;
+
+/// <summary>
+/// Extension methods for working with EventMetadata values.
+/// EventMetadata.Value is object?, but after round-trip through storage,
+/// non-null values materialize as JsonElement rather than their original CLR types.
+/// These helpers provide safe, typed access to common metadata value types.
+/// </summary>
+public static class EventMetadataExtensions
+{
+    /// <summary>
+    /// Safely gets a string value from metadata.
+    /// Returns null if the metadata is not found or the value is null.
+    /// </summary>
+    public static string? GetString(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is string str)
+            return str;
+
+        if (meta.Value is JsonElement jsonElement && jsonElement.ValueKind == JsonValueKind.String)
+            return jsonElement.GetString();
+
+        return meta.Value.ToString();
+    }
+
+    /// <summary>
+    /// Safely gets a DateTime value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static DateTime? GetDateTime(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is DateTime dt)
+            return dt;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                return jsonElement.TryGetDateTime(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets a Guid value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static Guid? GetGuid(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is Guid guid)
+            return guid;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                return jsonElement.TryGetGuid(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets an int value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static int? GetInt32(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is int i)
+            return i;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                return jsonElement.TryGetInt32(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets a long value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static long? GetInt64(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is long l)
+            return l;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                return jsonElement.TryGetInt64(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets a decimal value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static decimal? GetDecimal(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is decimal d)
+            return d;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                return jsonElement.TryGetDecimal(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets a double value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static double? GetDouble(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is double dbl)
+            return dbl;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                return jsonElement.TryGetDouble(out var parsed) ? parsed : null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Safely gets a boolean value from metadata.
+    /// Returns null if the metadata is not found, the value is null, or cannot be parsed.
+    /// </summary>
+    public static bool? GetBoolean(this IReadOnlyList<EventMetadata> metadata, string key)
+    {
+        var meta = metadata.FirstOrDefault(m => m.Key == key);
+        if (meta?.Value is null)
+            return null;
+
+        if (meta.Value is bool b)
+            return b;
+
+        if (meta.Value is JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                return jsonElement.GetBoolean();
+            }
+        }
+
+        return null;
+    }
+}

--- a/Rickten.Projector/README.md
+++ b/Rickten.Projector/README.md
@@ -279,19 +279,33 @@ public class CompletedSessionsProjection : Projection<CompletedView>
 
 ### Using Metadata
 
+EventMetadata values are stored as `object?`, but after round-trip through storage, they materialize as `JsonElement` rather than their original CLR types. Use the safe typed extension methods:
+
 ```csharp
 protected override AuditView ApplyEvent(AuditView view, StreamEvent streamEvent)
 {
-    var timestamp = streamEvent.Metadata
-        .FirstOrDefault(m => m.Key == "Timestamp")?.Value as DateTime?;
-
-    var userId = streamEvent.Metadata
-        .FirstOrDefault(m => m.Key == "UserId")?.Value as string;
+    // Use extension methods for safe, typed access
+    var timestamp = streamEvent.Metadata.GetDateTime("Timestamp");
+    var userId = streamEvent.Metadata.GetString("UserId");
+    var correlationId = streamEvent.Metadata.GetGuid("CorrelationId");
+    var count = streamEvent.Metadata.GetInt32("Count");
 
     // Use metadata in projection logic
     return view with { /* ... */ };
 }
 ```
+
+**Available Extension Methods:**
+- `GetString(key)` - Returns `string?`
+- `GetDateTime(key)` - Returns `DateTime?`
+- `GetGuid(key)` - Returns `Guid?`
+- `GetInt32(key)` - Returns `int?`
+- `GetInt64(key)` - Returns `long?`
+- `GetDecimal(key)` - Returns `decimal?`
+- `GetDouble(key)` - Returns `double?`
+- `GetBoolean(key)` - Returns `bool?`
+
+All methods return `null` if the key is not found or the value is null.
 
 ## Relationship to Other Packages
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -405,6 +405,29 @@ public sealed record EventMetadata(
 - `Key` (string): The metadata key
 - `Value` (object?): The metadata value
 
+**Important: Value Type After Storage**
+
+After round-trip through storage, non-null `Value` instances materialize as `System.Text.Json.JsonElement` rather than their original CLR types due to JSON serialization. Use the provided extension methods for safe, typed access:
+
+```csharp
+// Use extension methods on IReadOnlyList<EventMetadata>
+var timestamp = metadata.GetDateTime("Timestamp");
+var userId = metadata.GetString("UserId");
+var correlationId = metadata.GetGuid("CorrelationId");
+
+// Available: GetString, GetDateTime, GetGuid, GetInt32, GetInt64, 
+//            GetDecimal, GetDouble, GetBoolean
+```
+
+**Do not use direct casts** - they will fail after storage:
+```csharp
+// ? This will fail after round-trip
+var timestamp = metadata.First(m => m.Key == "Timestamp").Value as DateTime?;
+
+// ? Use this instead
+var timestamp = metadata.GetDateTime("Timestamp");
+```
+
 ---
 
 ### Snapshot

--- a/docs/API.md
+++ b/docs/API.md
@@ -421,10 +421,10 @@ var correlationId = metadata.GetGuid("CorrelationId");
 
 **Do not use direct casts** - they will fail after storage:
 ```csharp
-// ? This will fail after round-trip
+// Avoid: This will fail after round-trip through storage
 var timestamp = metadata.First(m => m.Key == "Timestamp").Value as DateTime?;
 
-// ? Use this instead
+// Recommended: Use the typed extension method instead
 var timestamp = metadata.GetDateTime("Timestamp");
 ```
 


### PR DESCRIPTION
- Added EventMetadataExtensions with safe typed accessors
- Added MetadataValueTypingTests documenting JsonElement behavior
- Added EventMetadataExtensionsTests with full coverage
- Updated Projector README to use safe helpers instead of casts
- Updated main README and API docs with typing guidance

EventMetadata.Value is object?, but after JSON serialization, values materialize as JsonElement. The extension methods handle both cases, providing a reliable API for consumers.

Tests: All 209 EventStore tests pass (27 new tests added)