### PR TITLE
docs: clarify EF provider/package boundary and database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,8 +919,8 @@ public class OrderQueryHandler
 ### Included Providers
 
 **Rickten.EventStore.EntityFramework includes:**
-- ✅ **SQL Server** - First-class support with `AddEventStoreSqlServer()` helper methods
-- ✅ **InMemory** - First-class support with `AddEventStoreInMemory()` helper methods for testing
+- **SQL Server** - First-class support with `AddEventStoreSqlServer()` helper methods
+- **InMemory** - First-class support with `AddEventStoreInMemory()` helper methods for testing
 
 ### SQL Server
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dotnet add package Rickten.EventStore
 ```
 
 ### **Rickten.EventStore.EntityFramework**
-Entity Framework Core implementation of the event store with support for SQL Server, PostgreSQL, SQLite, and in-memory databases.
+Entity Framework Core implementation of the event store. **Includes SQL Server and InMemory providers.** Supports other EF Core providers (PostgreSQL, SQLite, etc.) through generic `DbContextOptions` configuration when you install the provider package separately.
 
 ```bash
 dotnet add package Rickten.EventStore.EntityFramework
@@ -65,7 +65,7 @@ dotnet add package Rickten.Projector
 - ✅ **Snapshots** - Optimize aggregate rebuilding with state snapshots
 - ✅ **Projections** - Build read models from event streams
 - ✅ **Dependency Injection** - First-class DI support with flexible configuration
-- ✅ **Multiple Storage Options** - SQL Server, PostgreSQL, SQLite, In-Memory
+- ✅ **Multiple Storage Options** - SQL Server and InMemory included; PostgreSQL, SQLite, and other EF Core providers supported via generic configuration
 - ✅ **Async/Await** - Modern async patterns with `IAsyncEnumerable`
 - ✅ **Strong Typing** - Type-safe event handling with records
 - ✅ **Metadata Support** - Attach metadata to events (correlation IDs, causation IDs, etc.)
@@ -80,10 +80,11 @@ dotnet add package Rickten.EventStore.EntityFramework
 # Optional: Add aggregator support
 dotnet add package Rickten.Aggregator
 
-# Optional: Add database-specific providers
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
-dotnet add package Microsoft.EntityFrameworkCore.Sqlite
+# For database providers:
+# - SQL Server and InMemory providers are included in Rickten.EventStore.EntityFramework
+# - For other databases, install the provider package separately:
+dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL  # For PostgreSQL
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite   # For SQLite
 ```
 
 ### ⚠️ Type Registration Requirement
@@ -915,7 +916,15 @@ public class OrderQueryHandler
 
 ## 🗄️ Database Configuration
 
+### Included Providers
+
+**Rickten.EventStore.EntityFramework includes:**
+- ✅ **SQL Server** - First-class support with `AddEventStoreSqlServer()` helper methods
+- ✅ **InMemory** - First-class support with `AddEventStoreInMemory()` helper methods for testing
+
 ### SQL Server
+
+SQL Server is bundled with first-class helper methods:
 
 ```csharp
 services.AddEventStoreSqlServer(
@@ -929,11 +938,27 @@ services.AddEventStoreSqlServer(
     });
 ```
 
-### PostgreSQL
+### InMemory (Testing)
+
+InMemory provider is bundled with first-class helper methods:
+
+```csharp
+services.AddEventStoreInMemory("TestDb", typeof(MyEvent).Assembly);
+```
+
+### Other EF Core Providers
+
+**PostgreSQL, SQLite, and other EF Core providers** are supported through the generic `AddEventStore()` method, but you must install the provider package separately. Rickten does not bundle these providers or provide dedicated helper methods like `AddEventStorePostgres()`.
+
+#### PostgreSQL
+
+**Step 1:** Install the Npgsql provider package in your application:
 
 ```bash
 dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL
 ```
+
+**Step 2:** Use the generic `AddEventStore()` method:
 
 ```csharp
 // Must provide assemblies
@@ -959,11 +984,15 @@ services.AddEventStore<MyEvent>(options =>
 });
 ```
 
-### SQLite
+#### SQLite
+
+**Step 1:** Install the SQLite provider package in your application:
 
 ```bash
 dotnet add package Microsoft.EntityFrameworkCore.Sqlite
 ```
+
+**Step 2:** Use the generic `AddEventStore()` method:
 
 ```csharp
 // Must provide assemblies
@@ -976,6 +1005,24 @@ services.AddEventStore(options =>
 services.AddEventStore<MyEvent>(options =>
 {
     options.UseSqlite("Data Source=eventstore.db");
+});
+```
+
+#### Other Providers
+
+Any EF Core provider that supports relational databases can be used:
+
+```csharp
+// Example: MySQL (requires Pomelo.EntityFrameworkCore.MySql package)
+services.AddEventStore<MyEvent>(options =>
+{
+    options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
+});
+
+// Example: Oracle (requires Oracle.EntityFrameworkCore package)
+services.AddEventStore<MyEvent>(options =>
+{
+    options.UseOracle(connectionString);
 });
 ```
 

--- a/Rickten.EventStore.EntityFramework/Rickten.EventStore.EntityFramework.csproj
+++ b/Rickten.EventStore.EntityFramework/Rickten.EventStore.EntityFramework.csproj
@@ -14,13 +14,13 @@
     <Authors>Rickten</Authors>
     <Company>Rickten</Company>
     <Product>Rickten.EventStore.EntityFramework</Product>
-    <Description>Entity Framework Core implementation for Rickten.EventStore. Provides storage for events, snapshots, and projections using SQL Server, PostgreSQL, SQLite, and other EF Core providers. Includes dependency injection extensions for easy setup.</Description>
+    <Description>Entity Framework Core implementation for Rickten.EventStore. Provides storage for events, snapshots, and projections with included SQL Server and InMemory providers. Supports other EF Core providers (PostgreSQL, SQLite, etc.) through generic DbContextOptions configuration when you install the provider package separately. Includes dependency injection extensions for easy setup.</Description>
     <Copyright>Copyright (c) 2025 Rickten</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/zebrai2/rickten.eventstore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/zebrai2/rickten.eventstore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>event-sourcing;cqrs;ddd;entity-framework;ef-core;event-store;snapshots;projections;sql-server;postgresql;dotnet;csharp</PackageTags>
+    <PackageTags>event-sourcing;cqrs;ddd;entity-framework;ef-core;event-store;snapshots;projections;sql-server;dotnet;csharp</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon-128.png</PackageIcon>
     <PackageReleaseNotes>Initial release with Entity Framework Core support for event sourcing, snapshots, and projections. Includes dependency injection extensions.</PackageReleaseNotes>

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,18 @@
 
 Complete API documentation for Rickten.EventStore.
 
+## EF Core Provider Support
+
+**Rickten.EventStore.EntityFramework includes:**
+- ? **SQL Server** - Bundled with first-class `AddEventStoreSqlServer()` helper methods
+- ? **InMemory** - Bundled with first-class `AddEventStoreInMemory()` helper methods for testing
+
+**Other EF Core providers** (PostgreSQL, SQLite, MySQL, Oracle, etc.) are supported through the generic `AddEventStore(options => ...)` method. To use these providers:
+1. Install the provider package in your application (e.g., `Npgsql.EntityFrameworkCore.PostgreSQL` or `Microsoft.EntityFrameworkCore.Sqlite`)
+2. Configure using `AddEventStore()` with the provider's `Use*()` method (see [AddEventStore](#addeventstore) examples)
+
+Rickten does not bundle these providers or provide dedicated helper methods like `AddEventStorePostgres()` or `AddEventStoreSqlite()`.
+
 ## Table of Contents
 
 - [Core Abstractions](#core-abstractions)
@@ -575,10 +587,26 @@ public static IServiceCollection AddEventStore(
 
 **Example:**
 ```csharp
+// SQL Server (bundled provider)
 services.AddEventStore(options =>
 {
     options.UseSqlServer(connectionString);
 }, typeof(MyEvent).Assembly, typeof(MyAggregate).Assembly);
+
+// PostgreSQL (requires Npgsql.EntityFrameworkCore.PostgreSQL package)
+services.AddEventStore(options =>
+{
+    options.UseNpgsql(connectionString, npgsqlOptions =>
+    {
+        npgsqlOptions.EnableRetryOnFailure(5);
+    });
+}, typeof(MyEvent).Assembly);
+
+// SQLite (requires Microsoft.EntityFrameworkCore.Sqlite package)
+services.AddEventStore(options =>
+{
+    options.UseSqlite("Data Source=eventstore.db");
+}, typeof(MyEvent).Assembly);
 ```
 
 **Marker-Type Overloads:**
@@ -612,6 +640,21 @@ services.AddEventStore<OrderCreatedEvent>(options =>
     options.UseSqlServer(connectionString);
 });
 
+// PostgreSQL example (requires Npgsql.EntityFrameworkCore.PostgreSQL package)
+services.AddEventStore<OrderCreatedEvent>(options =>
+{
+    options.UseNpgsql(connectionString, npgsqlOptions =>
+    {
+        npgsqlOptions.EnableRetryOnFailure(5);
+    });
+});
+
+// SQLite example (requires Microsoft.EntityFrameworkCore.Sqlite package)
+services.AddEventStore<OrderCreatedEvent>(options =>
+{
+    options.UseSqlite("Data Source=eventstore.db");
+});
+
 // Multiple assemblies using marker types
 services.AddEventStore<OrderCreatedEvent, CustomerAggregate>(options =>
 {
@@ -621,7 +664,7 @@ services.AddEventStore<OrderCreatedEvent, CustomerAggregate>(options =>
 
 #### AddEventStoreInMemory
 
-Registers all stores with in-memory database (for testing).
+Registers all stores with in-memory database using the bundled provider (for testing).
 
 **Primary Overload (Assembly Array):**
 ```csharp
@@ -681,7 +724,7 @@ services.AddEventStoreInMemory<OrderCreatedEvent, CustomerAggregate>("TestDb");
 
 #### AddEventStoreSqlServer
 
-Registers all stores with SQL Server.
+Registers all stores with SQL Server using the bundled provider.
 
 **Primary Overload (Assembly Array):**
 ```csharp

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,8 +5,8 @@ Complete API documentation for Rickten.EventStore.
 ## EF Core Provider Support
 
 **Rickten.EventStore.EntityFramework includes:**
-- ? **SQL Server** - Bundled with first-class `AddEventStoreSqlServer()` helper methods
-- ? **InMemory** - Bundled with first-class `AddEventStoreInMemory()` helper methods for testing
+- **SQL Server** - Bundled with first-class `AddEventStoreSqlServer()` helper methods
+- **InMemory** - Bundled with first-class `AddEventStoreInMemory()` helper methods for testing
 
 **Other EF Core providers** (PostgreSQL, SQLite, MySQL, Oracle, etc.) are supported through the generic `AddEventStore(options => ...)` method. To use these providers:
 1. Install the provider package in your application (e.g., `Npgsql.EntityFrameworkCore.PostgreSQL` or `Microsoft.EntityFrameworkCore.Sqlite`)


### PR DESCRIPTION
Clarifies which EF Core providers are bundled vs. supported through generic configuration:

Package changes:
- Updated package description to specify SQL Server and InMemory are included
- Removed misleading PostgreSQL tag from package metadata

README.md:
- Clarified that SQL Server and InMemory providers are bundled
- Added explicit section explaining bundled vs. other providers
- Enhanced PostgreSQL and SQLite examples with installation steps
- Added examples for MySQL and Oracle to demonstrate extensibility
- Updated feature list to be more accurate

docs/API.md:
- Added EF Core Provider Support section at the top
- Enhanced AddEventStore examples with PostgreSQL and SQLite
- Clarified that SQL Server/InMemory have first-class helpers
- Made it clear that other providers require separate package installation

No code changes or package dependency changes in this PR.

Fixes #7