### PR TITLE
StreamPointer: support direct comparison with long

### DIFF
--- a/Rickten.Aggregator/ARCHITECTURE.md
+++ b/Rickten.Aggregator/ARCHITECTURE.md
@@ -126,7 +126,7 @@ public async Task<(TState, StreamPointer, IReadOnlyList<StreamEvent>)> ExecuteAs
     var (state, currentPointer) = await repository.LoadStateAsync(streamIdentifier, ct);
 
     // Step 2: Validate expected version (if command declares ExpectedVersionKey)
-    if (expectedVersion.HasValue && currentPointer.Version != expectedVersion.Value)
+    if (expectedVersion.HasValue && currentPointer != expectedVersion.Value)
         throw new StreamVersionConflictException(...);
 
     // Step 3: Execute command → produce events

--- a/Rickten.Aggregator/AggregateCommandExecutor.cs
+++ b/Rickten.Aggregator/AggregateCommandExecutor.cs
@@ -51,7 +51,7 @@ public class AggregateCommandExecutor<TState, TCommand>
         var (state, currentPointer) = await _repository.LoadStateAsync(streamIdentifier, cancellationToken);
 
         var (expectedVersion, expectedVersionKey) = GetExpectedVersionFromMetadata(command, metadata);
-        if (expectedVersion.HasValue && currentPointer.Version != expectedVersion.Value)
+        if (expectedVersion.HasValue && currentPointer != expectedVersion.Value)
         {
             var expectedPointer = streamIdentifier.At(expectedVersion.Value);
             throw new StreamVersionConflictException(

--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -177,7 +177,7 @@ public sealed class EventStore(
         var loadedEvents = await _context.Events
             .Where(e => e.StreamType == streamType
                      && e.StreamIdentifier == streamIdentifier
-                     && expectedStreamVersion < e.Version)
+                     && e.Version > expectedStreamVersion)
             .OrderBy(e => e.Version)
             .ToListAsync(cancellationToken);
 

--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -107,7 +107,7 @@ public sealed class EventStore(
         var currentVersion = await streamEvents.GetCurrentVersionAsync(
                                                     expectedStream,
                                                     cancellationToken);
-        if (currentVersion != expectedVersion.Version)
+        if (expectedVersion != currentVersion)
         {
             throw new StreamVersionConflictException(
                 expectedVersion, new StreamPointer(expectedStream, currentVersion),
@@ -177,7 +177,7 @@ public sealed class EventStore(
         var loadedEvents = await _context.Events
             .Where(e => e.StreamType == streamType
                      && e.StreamIdentifier == streamIdentifier
-                     && e.Version > expectedStreamVersion)
+                     && expectedStreamVersion < e.Version)
             .OrderBy(e => e.Version)
             .ToListAsync(cancellationToken);
 

--- a/Rickten.EventStore.Tests/EventStoreTests.cs
+++ b/Rickten.EventStore.Tests/EventStoreTests.cs
@@ -294,7 +294,7 @@ public class EventStoreTests
         Assert.Equal(4, result2[1].StreamPointer.Version);
 
         // Verify no duplicate of version 2
-        Assert.DoesNotContain(result2, e => e.StreamPointer.Version == 2);
+        Assert.DoesNotContain(result2, e => e.StreamPointer == 2);
     }
 
     [Fact]
@@ -329,7 +329,7 @@ public class EventStoreTests
         Assert.Equal(5, loaded[1].StreamPointer.Version);
 
         // Verify version 3 is NOT included (this would be the bug)
-        Assert.DoesNotContain(loaded, e => e.StreamPointer.Version == 3);
+        Assert.DoesNotContain(loaded, e => e.StreamPointer == 3);
     }
 
     [Fact]

--- a/docs/API.md
+++ b/docs/API.md
@@ -334,12 +334,30 @@ Represents a pointer to a specific version within a stream.
 ```csharp
 public sealed record StreamPointer(
     StreamIdentifier Stream,
-    long Version);
+    long Version) : IComparable<StreamPointer>, IComparable<long>;
 ```
 
 **Properties:**
 - `Stream` (StreamIdentifier): The stream identifier
 - `Version` (long): The current stream version (last written event version). Version 0 indicates a new stream with no events. Version N means the stream has N events, and the next append will write version N+1.
+
+**Comparison Operators:**
+
+StreamPointer supports comparison with other StreamPointers or long values:
+
+```csharp
+var pointer1 = new StreamPointer(streamId, 5);
+var pointer2 = new StreamPointer(streamId, 10);
+
+// Compare StreamPointers (throws if streams don't match)
+if (pointer1 < pointer2) { /* ... */ }
+if (pointer1 >= pointer2) { /* ... */ }
+
+// Compare with long values
+if (pointer1 == 5) { /* ... */ }
+if (pointer2 > 5) { /* ... */ }
+if (10 <= pointer2) { /* ... */ }
+```
 
 **Example:**
 ```csharp


### PR DESCRIPTION
Fixes #28

Adds direct StreamPointer comparison support for stream-version checks and updates usage/docs to prefer comparing StreamPointer values where appropriate.

## Changes

- Added StreamPointer comparison support with other StreamPointer values and long stream-version values
- Updated aggregate command execution version validation to use StreamPointer comparison operators
- Updated EventStore concurrency checks to use StreamPointer comparison operators outside EF queries
- Kept EF LINQ predicates on primitive version values to preserve SQL translation
- Updated tests and API docs with comparison examples

## Testing

- Build and test workflow passing
Fixes #28

Adds direct StreamPointer comparison support for stream-version checks and updates usage/docs to prefer comparing StreamPointer values where appropriate.

## Changes

- Added StreamPointer comparison support with other StreamPointer values and long stream-version values
- Updated aggregate command execution version validation to use StreamPointer comparison operators
- Updated EventStore concurrency checks to use StreamPointer comparison operators outside EF queries
- Kept EF LINQ predicates on primitive version values to preserve SQL translation
- Updated tests and API docs with comparison examples

## Testing

- Build and test workflow passing
