### PR TITLE
Add reaction identity metadata to reaction-produced events

### DIFF
--- a/Rickten.EventStore.Tests/TraceIdentityMetadataTests.cs
+++ b/Rickten.EventStore.Tests/TraceIdentityMetadataTests.cs
@@ -180,5 +180,29 @@ public class TraceIdentityMetadataTests
         Assert.Equal(clientId, clientResult);
         Assert.Equal(systemId, systemResult);
     }
+
+    [Fact]
+    public void GetReactionWireName_Returns_Null_When_Not_Present()
+    {
+        var metadata = new List<EventMetadata>();
+
+        var result = metadata.GetReactionWireName();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetReactionWireName_Returns_String_When_Present()
+    {
+        var expectedWireName = "Reaction.MembershipChanged.MembershipReaction";
+        var metadata = new List<EventMetadata>
+        {
+            new EventMetadata(EventMetadataSource.Client, EventMetadataKeys.ReactionWireName, expectedWireName)
+        };
+
+        var result = metadata.GetReactionWireName();
+
+        Assert.Equal(expectedWireName, result);
+    }
 }
 

--- a/Rickten.EventStore/EventMetadataExtensions.cs
+++ b/Rickten.EventStore/EventMetadataExtensions.cs
@@ -299,5 +299,15 @@ public static class EventMetadataExtensions
     {
         return metadata.FirstOrDefault(m => m.Key == key);
     }
+
+    /// <summary>
+    /// Gets the wire name of the reaction that produced this event.
+    /// ReactionWireName identifies the reaction that executed the command that produced this event.
+    /// Format: Reaction.{Name}.{ClassName}
+    /// </summary>
+    public static string? GetReactionWireName(this IReadOnlyList<EventMetadata> metadata)
+    {
+        return metadata.GetString(EventMetadataKeys.ReactionWireName);
+    }
 }
 

--- a/Rickten.EventStore/EventMetadataKeys.cs
+++ b/Rickten.EventStore/EventMetadataKeys.cs
@@ -52,4 +52,12 @@ public static class EventMetadataKeys
     /// Type: long (System metadata source)
     /// </summary>
     public const string StreamVersion = "StreamVersion";
+
+    /// <summary>
+    /// The wire name of the reaction that produced this event.
+    /// Format: Reaction.{Name}.{ClassName}
+    /// Added by ReactionRunner when executing reaction-produced commands.
+    /// Type: string (Client metadata source)
+    /// </summary>
+    public const string ReactionWireName = "ReactionWireName";
 }

--- a/Rickten.Reactor.Tests/ReactionRunnerTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRunnerTests.cs
@@ -627,6 +627,69 @@ public class ReactionRunnerTests : IDisposable
             msg.Contains("projection is ahead of reaction checkpoint") &&
             msg.Contains("Rebuilding projection"));
     }
+
+    [Fact]
+    public async Task CatchUpAsync_AddsReactionIdentityMetadata_ToProducedEvents()
+    {
+        // Arrange
+        var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var registry = _serviceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+        var reaction = new MembershipDefinitionChangedReaction(registry);
+        var folder = new MembershipStateFolder(registry);
+        var decider = new MembershipCommandDecider();
+
+        // Create definition
+        var defStream = new StreamIdentifier("MembershipDefinition", "def-metadata");
+        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
+        {
+            new AppendEvent(new MembershipDefinitionChangedEvent("def-metadata", "Premium"), null)
+        });
+
+        // Register user with this definition
+        var userStream = new StreamIdentifier("User", "user-metadata");
+        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
+        {
+            new AppendEvent(new UserRegisteredEvent("user-metadata", "user@test.com", "def-metadata"), null)
+        });
+
+        // Change the definition - this should trigger a command
+        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
+        {
+            new AppendEvent(new MembershipDefinitionChangedEvent("def-metadata", "Premium Plus"), null)
+        });
+
+        // Act
+        var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
+        var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
+        await ReactionRunner.CatchUpAsync(
+            eventStore,
+            _projectionStore,
+            reaction,
+            executor);
+
+        // Assert - verify reaction-produced events have ReactionWireName metadata
+        var membershipStream = new StreamIdentifier("Membership", "user-metadata");
+        var events = new List<StreamEvent>();
+        await foreach (var evt in eventStore.LoadAsync(membershipStream, CancellationToken.None))
+        {
+            events.Add(evt);
+        }
+
+        Assert.Single(events);
+        var reactionEvent = events[0];
+
+        // Verify ReactionWireName metadata is present
+        var reactionWireName = reactionEvent.Metadata.GetReactionWireName();
+        Assert.NotNull(reactionWireName);
+        Assert.Equal("Reaction.MembershipDefinitionChanged.MembershipDefinitionChangedReaction", reactionWireName);
+
+        // Also verify CorrelationId and CausationId are propagated
+        var correlationId = reactionEvent.Metadata.GetCorrelationId();
+        var causationId = reactionEvent.Metadata.GetCausationId();
+
+        // CausationId should be set to the trigger event's EventId
+        Assert.NotNull(causationId);
+    }
 }
 
 // Simple test logger for capturing log messages

--- a/Rickten.Reactor/README.md
+++ b/Rickten.Reactor/README.md
@@ -309,6 +309,46 @@ public sealed class MembershipDefinitionChangedReaction
 - Commands **must be idempotent** (replay may occur after partial execution)
 - Projection state is always consistent with or ahead of reaction progress
 
+## Metadata Propagation
+
+When `ReactionRunner` executes commands in response to trigger events, it automatically adds metadata to the resulting events to maintain traceability:
+
+### Automatically Added Metadata
+
+1. **CorrelationId** - Propagated from trigger event (if present)
+   - Tracks related events across aggregate boundaries
+   - Source: `Client` (even if trigger was `System`)
+
+2. **CausationId** - Set to trigger event's system `EventId`
+   - References the event that caused this reaction
+   - Source: `Client`
+
+3. **ReactionWireName** - Identifies the reaction that produced the event
+   - Format: `Reaction.{Name}.{ClassName}`
+   - Example: `"Reaction.MembershipDefinitionChanged.MembershipDefinitionChangedReaction"`
+   - Source: `Client`
+
+### Reading Reaction Metadata
+
+Use the typed extension methods from `EventMetadataExtensions`:
+
+```csharp
+// Get the reaction that produced this event
+var reactionWireName = streamEvent.Metadata.GetReactionWireName();
+// Returns: "Reaction.MembershipDefinitionChanged.MembershipDefinitionChangedReaction"
+
+// Get the trigger event that caused this
+var causationId = streamEvent.Metadata.GetCausationId();
+
+// Get the correlation ID for distributed tracing
+var correlationId = streamEvent.Metadata.GetCorrelationId();
+```
+
+This enables:
+- **Debugging**: Trace which reaction produced specific events
+- **Monitoring**: Track reaction execution patterns
+- **Auditing**: Full causation chain from trigger to result
+
 ## Design Boundaries
 
 ### Included

--- a/Rickten.Reactor/Reaction.cs
+++ b/Rickten.Reactor/Reaction.cs
@@ -36,13 +36,19 @@ public abstract class Reaction<TView, TCommand>
                 $"Reaction type '{implementationType.Name}' must be decorated with [Reaction] attribute.");
         }
 
-        _reactionInfo = new ReactionInfo(reactionAttr.Name, reactionAttr.EventTypes);
+        _reactionInfo = new ReactionInfo(reactionAttr.Name, reactionAttr.EventTypes, metadata.WireName);
     }
 
     /// <summary>
     /// Gets the reaction name from the [Reaction] attribute.
     /// </summary>
     public string ReactionName => _reactionInfo.Name;
+
+    /// <summary>
+    /// Gets the wire name of this reaction.
+    /// Format: Reaction.{Name}.{ClassName}
+    /// </summary>
+    public string? WireName => _reactionInfo.WireName;
 
     /// <summary>
     /// Gets the event type filter from the [Reaction] attribute, if configured.
@@ -127,4 +133,4 @@ public abstract class Reaction<TView, TCommand>
 /// <summary>
 /// Internal record to hold reaction metadata.
 /// </summary>
-internal sealed record ReactionInfo(string Name, string[]? EventTypes);
+internal sealed record ReactionInfo(string Name, string[]? EventTypes, string? WireName);

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -205,6 +205,12 @@ public static class ReactionRunner
                     reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.CausationId, triggerEventId.Value));
                 }
 
+                // Add reaction identity metadata
+                if (reaction.WireName != null)
+                {
+                    reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.ReactionWireName, reaction.WireName));
+                }
+
                 // Execute commands against each selected stream
                 foreach (var (targetStream, command) in commands)
                 {


### PR DESCRIPTION
Fixes #32

When ReactionRunner executes commands, the resulting events now include metadata identifying the reaction that produced them.

Changes:
- Added EventMetadataKeys.ReactionWireName constant
- Added GetReactionWireName() extension method
- Exposed WireName property on Reaction base class
- ReactionRunner now adds ReactionWireName metadata when executing commands
- Added tests for metadata propagation
- Updated Reactor README with metadata documentation

The reaction wire name format is: Reaction.{Name}.{ClassName} This enables debugging, monitoring, and auditing of reaction execution.