### PR TITLE
Refactor ReactionRunner into instance-based checkpointed service

### DIFF
--- a/Rickten.Aggregator/StateFolder.cs
+++ b/Rickten.Aggregator/StateFolder.cs
@@ -76,7 +76,9 @@ public abstract class StateFolder<TState> : IStateFolder<TState>
         // Look up handler method for this event type
         if (_info.Handlers.TryGetValue(eventType, out var handler))
         {
-            return (TState)handler.Invoke(this, [@event, state])!;
+            // Use null target for static methods, 'this' for instance methods
+            var target = handler.IsStatic ? null : this;
+            return (TState)handler.Invoke(target, [@event, state])!;
         }
 
         // No handler found - return state unchanged
@@ -107,7 +109,8 @@ public abstract class StateFolder<TState> : IStateFolder<TState>
         var handlers = new Dictionary<Type, MethodInfo>();
 
         // Find all protected methods named "When" with signature: TState When(EventType, TState)
-        var methods = implementationType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+        // Support both static and instance methods
+        var methods = implementationType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
             .Where(m => m.Name == "When" && m.ReturnType == typeof(TState));
 
         foreach (var method in methods)

--- a/Rickten.EventStore.EntityFramework/Entities/ReactionEntity.cs
+++ b/Rickten.EventStore.EntityFramework/Entities/ReactionEntity.cs
@@ -1,0 +1,27 @@
+namespace Rickten.EventStore.EntityFramework.Entities;
+
+/// <summary>
+/// Entity representing a reaction checkpoint in the event store.
+/// </summary>
+public sealed class ReactionEntity
+{
+    /// <summary>
+    /// Gets or sets the unique reaction name.
+    /// </summary>
+    public required string ReactionName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the global position of the last processed trigger event.
+    /// </summary>
+    public long TriggerPosition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the global position of the last event applied to the projection view.
+    /// </summary>
+    public long ProjectionPosition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when this checkpoint was last updated.
+    /// </summary>
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -72,6 +72,83 @@ public sealed class EventStore(
         }
     }
 
+    /// <inheritdoc />
+    public async IAsyncEnumerable<(StreamEvent Event, int[] MatchingFilters)> LoadAllMergedAsync(
+        long fromGlobalPosition,
+        (string[]? streamTypeFilter, string[]? eventsFilter)[] filters,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (filters.Length == 0)
+        {
+            yield break;
+        }
+
+        // Load streams for each filter
+        var streams = filters.Select((filter, index) =>
+            LoadAllAsync(fromGlobalPosition, filter.streamTypeFilter, filter.eventsFilter, cancellationToken)
+        ).ToArray();
+
+        // Use the extension method to merge, but we need to track which filter each stream came from
+        // Since we need to know ALL matching filters for each event, we'll do this manually
+        var enumerators = streams.Select(s => s.GetAsyncEnumerator(cancellationToken)).ToArray();
+        var hasMore = new bool[filters.Length];
+
+        try
+        {
+            // Initialize all enumerators
+            for (int i = 0; i < enumerators.Length; i++)
+            {
+                hasMore[i] = await enumerators[i].MoveNextAsync();
+            }
+
+            while (hasMore.Any(h => h))
+            {
+                // Find the minimum position among all active streams
+                long minPosition = long.MaxValue;
+                for (int i = 0; i < enumerators.Length; i++)
+                {
+                    if (hasMore[i])
+                    {
+                        var pos = enumerators[i].Current.GlobalPosition;
+                        if (pos < minPosition)
+                        {
+                            minPosition = pos;
+                        }
+                    }
+                }
+
+                // Collect all filters that have this position
+                var matchingFilterIndices = new List<int>();
+                StreamEvent? eventToYield = null;
+
+                for (int i = 0; i < enumerators.Length; i++)
+                {
+                    if (hasMore[i] && enumerators[i].Current.GlobalPosition == minPosition)
+                    {
+                        if (eventToYield == null)
+                        {
+                            eventToYield = enumerators[i].Current;
+                        }
+                        matchingFilterIndices.Add(i);
+                        hasMore[i] = await enumerators[i].MoveNextAsync();
+                    }
+                }
+
+                if (eventToYield != null)
+                {
+                    yield return (eventToYield, [.. matchingFilterIndices]);
+                }
+            }
+        }
+        finally
+        {
+            foreach (var enumerator in enumerators)
+            {
+                await enumerator.DisposeAsync();
+            }
+        }
+    }
+
     private static List<EventMetadata> TransformAppendMetadata(IReadOnlyList<AppendMetadata>? appendMetadata)
     {
         var metadata = new List<EventMetadata>();

--- a/Rickten.EventStore.EntityFramework/EventStoreDbContext.cs
+++ b/Rickten.EventStore.EntityFramework/EventStoreDbContext.cs
@@ -32,6 +32,11 @@ public sealed class EventStoreDbContext : DbContext
     /// </summary>
     public DbSet<ProjectionEntity> Projections { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the reactions table.
+    /// </summary>
+    public DbSet<ReactionEntity> Reactions { get; set; } = null!;
+
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -133,6 +138,27 @@ public sealed class EventStoreDbContext : DbContext
                 .HasMaxLength(255);
 
             entity.Property(e => e.State)
+                .IsRequired();
+
+            entity.Property(e => e.UpdatedAt)
+                .IsRequired()
+                .HasDefaultValueSql(utcNowSql);
+        });
+
+        // Configure ReactionEntity
+        modelBuilder.Entity<ReactionEntity>(entity =>
+        {
+            entity.ToTable("Reactions");
+            entity.HasKey(e => e.ReactionName);
+
+            entity.Property(e => e.ReactionName)
+                .IsRequired()
+                .HasMaxLength(255);
+
+            entity.Property(e => e.TriggerPosition)
+                .IsRequired();
+
+            entity.Property(e => e.ProjectionPosition)
                 .IsRequired();
 
             entity.Property(e => e.UpdatedAt)

--- a/Rickten.EventStore.EntityFramework/ReactionRepository.cs
+++ b/Rickten.EventStore.EntityFramework/ReactionRepository.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using Rickten.EventStore.EntityFramework.Entities;
+
+namespace Rickten.EventStore.EntityFramework;
+
+/// <summary>
+/// Entity Framework Core implementation of <see cref="IReactionRepository"/>.
+/// </summary>
+public sealed class ReactionRepository(EventStoreDbContext context) : IReactionRepository
+{
+    private readonly EventStoreDbContext _context = context ?? throw new ArgumentNullException(nameof(context));
+
+    public async Task<ReactionCheckpoint?> LoadCheckpointAsync(
+        string reactionName,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Reactions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.ReactionName == reactionName, cancellationToken);
+
+        if (entity == null)
+        {
+            return null;
+        }
+
+        return new ReactionCheckpoint(
+            reactionName,
+            entity.TriggerPosition,
+            entity.ProjectionPosition);
+    }
+
+    public async Task SaveCheckpointAsync(
+        ReactionCheckpoint checkpoint,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Reactions
+            .FirstOrDefaultAsync(r => r.ReactionName == checkpoint.ReactionName, cancellationToken);
+
+        if (entity == null)
+        {
+            entity = new ReactionEntity
+            {
+                ReactionName = checkpoint.ReactionName,
+                TriggerPosition = checkpoint.TriggerPosition,
+                ProjectionPosition = checkpoint.ProjectionPosition,
+                UpdatedAt = DateTime.UtcNow
+            };
+            _context.Reactions.Add(entity);
+        }
+        else
+        {
+            entity.TriggerPosition = checkpoint.TriggerPosition;
+            entity.ProjectionPosition = checkpoint.ProjectionPosition;
+            entity.UpdatedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Rickten.EventStore.EntityFramework/ServiceCollectionExtensions.cs
+++ b/Rickten.EventStore.EntityFramework/ServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IEventStore, EventStore>();
         services.TryAddScoped<ISnapshotStore, SnapshotStore>();
         services.TryAddScoped<IProjectionStore, ProjectionStore>();
+        services.TryAddScoped<IReactionRepository, ReactionRepository>();
 
         return services;
     }

--- a/Rickten.EventStore/IEventStore.cs
+++ b/Rickten.EventStore/IEventStore.cs
@@ -34,6 +34,19 @@ public interface IEventStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Loads events from multiple filter configurations and merges them by global position.
+    /// When the same event matches multiple filters, it is yielded once with all matching filter indices.
+    /// </summary>
+    /// <param name="fromGlobalPosition">The global position to start loading after (exclusive).</param>
+    /// <param name="filters">Array of filter configurations (streamTypeFilter, eventsFilter). Each tuple represents a separate query.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>An async enumerable of tuples containing the event and array of matching filter indices.</returns>
+    IAsyncEnumerable<(StreamEvent Event, int[] MatchingFilters)> LoadAllMergedAsync(
+        long fromGlobalPosition,
+        (string[]? streamTypeFilter, string[]? eventsFilter)[] filters,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Appends events to a stream with optimistic concurrency control.
     /// </summary>
     /// <param name="expectedVersion">

--- a/Rickten.EventStore/IReactionRepository.cs
+++ b/Rickten.EventStore/IReactionRepository.cs
@@ -1,0 +1,26 @@
+namespace Rickten.EventStore;
+
+/// <summary>
+/// Repository for managing reaction execution checkpoints.
+/// </summary>
+public interface IReactionRepository
+{
+    /// <summary>
+    /// Loads a reaction checkpoint by its name.
+    /// </summary>
+    /// <param name="reactionName">The unique name of the reaction.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The reaction checkpoint if it exists, otherwise null.</returns>
+    Task<ReactionCheckpoint?> LoadCheckpointAsync(
+        string reactionName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves a reaction checkpoint.
+    /// </summary>
+    /// <param name="checkpoint">The reaction checkpoint to save.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    Task SaveCheckpointAsync(
+        ReactionCheckpoint checkpoint,
+        CancellationToken cancellationToken = default);
+}

--- a/Rickten.EventStore/ReactionCheckpoint.cs
+++ b/Rickten.EventStore/ReactionCheckpoint.cs
@@ -1,0 +1,12 @@
+namespace Rickten.EventStore;
+
+/// <summary>
+/// Represents a reaction's checkpoint tracking execution progress.
+/// </summary>
+/// <param name="ReactionName">The unique name of the reaction.</param>
+/// <param name="TriggerPosition">The global position of the last processed trigger event.</param>
+/// <param name="ProjectionPosition">The global position of the last event applied to the projection view.</param>
+public sealed record ReactionCheckpoint(
+    string ReactionName,
+    long TriggerPosition,
+    long ProjectionPosition);

--- a/Rickten.Projector/IProjection.cs
+++ b/Rickten.Projector/IProjection.cs
@@ -9,6 +9,26 @@ namespace Rickten.Projector;
 public interface IProjection<TView>
 {
     /// <summary>
+    /// Gets the projection name. Used for checkpoint storage.
+    /// If null, the projection name must be provided explicitly to projection runners.
+    /// </summary>
+    string? ProjectionName => null;
+
+    /// <summary>
+    /// Gets the optional aggregate type filter.
+    /// When set, only events from these aggregate types will be loaded.
+    /// Null means no filtering (all aggregate types).
+    /// </summary>
+    string[]? AggregateTypeFilter => null;
+
+    /// <summary>
+    /// Gets the optional event type filter.
+    /// When set, only events of these types will be loaded.
+    /// Null means no filtering (all event types).
+    /// </summary>
+    string[]? EventTypeFilter => null;
+
+    /// <summary>
     /// Gets the initial view before any events are applied.
     /// </summary>
     /// <returns>The initial view state.</returns>

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -26,21 +26,11 @@ public static class ProjectionRunner
         var view = projection.InitialView();
         long lastGlobalPosition = fromGlobalPosition;
 
-        // Get filters from projection if it's a Projection<T>
-        string[]? aggregateFilter = null;
-        string[]? eventTypeFilter = null;
-
-        if (projection is Projection<TView> proj)
-        {
-            aggregateFilter = proj.AggregateTypeFilter;
-            eventTypeFilter = proj.EventTypeFilter;
-        }
-
         // Load events with optional filtering
         await foreach (var streamEvent in eventStore.LoadAllAsync(
             fromGlobalPosition,
-            aggregateFilter,
-            eventTypeFilter,
+            projection.AggregateTypeFilter,
+            projection.EventTypeFilter,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
@@ -72,21 +62,11 @@ public static class ProjectionRunner
         var view = projection.InitialView();
         long lastGlobalPosition = fromGlobalPosition;
 
-        // Get filters from projection if it's a Projection<T>
-        string[]? aggregateFilter = null;
-        string[]? eventTypeFilter = null;
-
-        if (projection is Projection<TView> proj)
-        {
-            aggregateFilter = proj.AggregateTypeFilter;
-            eventTypeFilter = proj.EventTypeFilter;
-        }
-
         // Load events with optional filtering, stopping at untilGlobalPosition (inclusive)
         await foreach (var streamEvent in eventStore.LoadAllAsync(
             fromGlobalPosition,
-            aggregateFilter,
-            eventTypeFilter,
+            projection.AggregateTypeFilter,
+            projection.EventTypeFilter,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
@@ -145,9 +125,9 @@ public static class ProjectionRunner
     {
         // Determine projection name
         var name = projectionName;
-        if (string.IsNullOrEmpty(name) && projection is Projection<TView> proj)
+        if (string.IsNullOrEmpty(name))
         {
-            name = proj.ProjectionName;
+            name = projection.ProjectionName;
         }
         if (string.IsNullOrEmpty(name))
         {
@@ -161,22 +141,12 @@ public static class ProjectionRunner
         var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
         var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
 
-        // Get filters
-        string[]? aggregateFilter = null;
-        string[]? eventTypeFilter = null;
-
-        if (projection is Projection<TView> p)
-        {
-            aggregateFilter = p.AggregateTypeFilter;
-            eventTypeFilter = p.EventTypeFilter;
-        }
-
         // Process new events
         var lastGlobalPosition = fromGlobalPosition;
         await foreach (var streamEvent in eventStore.LoadAllAsync(
             fromGlobalPosition,
-            aggregateFilter,
-            eventTypeFilter,
+            projection.AggregateTypeFilter,
+            projection.EventTypeFilter,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
@@ -190,5 +160,128 @@ public static class ProjectionRunner
         }
 
         return (view, lastGlobalPosition);
+    }
+
+    /// <summary>
+    /// Catches up a projection from its last checkpoint up to a specific position (inclusive).
+    /// Loads the checkpoint from the projection store, applies events up to the target position, and saves if progress was made.
+    /// </summary>
+    /// <typeparam name="TView">The view type.</typeparam>
+    /// <param name="eventStore">The event store to load events from.</param>
+    /// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
+    /// <param name="projection">The projection to apply.</param>
+    /// <param name="untilGlobalPosition">Process events up to and including this global position.</param>
+    /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
+    /// <param name="namespace">The namespace for the projection.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The projected view and the last processed global position.</returns>
+    public static async Task<(TView View, long GlobalPosition)> CatchUpUntilAsync<TView>(
+        IEventStore eventStore,
+        IProjectionStore projectionStore,
+        IProjection<TView> projection,
+        long untilGlobalPosition,
+        string? projectionName = null,
+        string @namespace = "system",
+        CancellationToken cancellationToken = default)
+    {
+        // Determine projection name
+        var name = projectionName;
+        if (string.IsNullOrEmpty(name))
+        {
+            name = projection.ProjectionName;
+        }
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException(
+                "Projection name must be provided either via parameter or [Projection] attribute",
+                nameof(projectionName));
+        }
+
+        // Load last checkpoint
+        var checkpoint = await projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
+        var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
+        var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
+
+        // Process events up to target position
+        var lastGlobalPosition = fromGlobalPosition;
+        await foreach (var streamEvent in eventStore.LoadAllAsync(
+            fromGlobalPosition,
+            projection.AggregateTypeFilter,
+            projection.EventTypeFilter,
+            cancellationToken))
+        {
+            view = projection.Apply(view, streamEvent);
+            lastGlobalPosition = streamEvent.GlobalPosition;
+
+            // Stop if we've reached the target position (inclusive)
+            if (streamEvent.GlobalPosition >= untilGlobalPosition)
+            {
+                break;
+            }
+        }
+
+        // Save updated checkpoint if we processed any events
+        if (lastGlobalPosition > fromGlobalPosition)
+        {
+            await projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
+        }
+
+        return (view, lastGlobalPosition);
+    }
+
+    /// <summary>
+    /// Synchronizes a projection view to a target position.
+    /// If current position is ahead of target, rebuilds from scratch (can't go backwards).
+    /// If current position is behind target, catches up from checkpoint.
+    /// If equal, returns current view unchanged.
+    /// </summary>
+    /// <typeparam name="TView">The view type.</typeparam>
+    /// <param name="eventStore">The event store to load events from.</param>
+    /// <param name="projectionStore">The projection store for loading checkpoints.</param>
+    /// <param name="projection">The projection to apply.</param>
+    /// <param name="currentView">The current projection view state.</param>
+    /// <param name="currentPosition">The current projection position.</param>
+    /// <param name="targetPosition">The target position to synchronize to.</param>
+    /// <param name="projectionName">The name to use for loading the projection (defaults to projection's name if available).</param>
+    /// <param name="namespace">The namespace for the projection.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The synchronized view and position.</returns>
+    public static async Task<(TView View, long Position)> SyncToPositionAsync<TView>(
+        IEventStore eventStore,
+        IProjectionStore projectionStore,
+        IProjection<TView> projection,
+        TView currentView,
+        long currentPosition,
+        long targetPosition,
+        string? projectionName = null,
+        string @namespace = "system",
+        CancellationToken cancellationToken = default)
+    {
+        if (currentPosition > targetPosition)
+        {
+            // Projection ahead - must rebuild from scratch (can't go backwards)
+            return await RebuildUntilAsync(
+                eventStore,
+                projection,
+                targetPosition,
+                fromGlobalPosition: 0,
+                cancellationToken);
+        }
+
+        if (currentPosition < targetPosition)
+        {
+            // Projection behind - catch up from checkpoint
+            return await CatchUpUntilAsync(
+                eventStore,
+                projectionStore,
+                projection,
+                targetPosition,
+                projectionName,
+                @namespace,
+                cancellationToken);
+        }
+
+        // Equal - no action needed
+        return (currentView, currentPosition);
     }
 }

--- a/Rickten.Reactor.Tests/ReactionRegistrationTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRegistrationTests.cs
@@ -151,7 +151,7 @@ public class ReactionWithoutAttribute : Reaction<TestView, TestCommand>
 
 // Test reactions for registration
 
-[Reaction("TestReaction")]
+[Reaction("TestReaction", ["Test.Event.v1"])]
 public class TestRegisteredReaction : Reaction<TestView, TestCommand>
 {
     private readonly TestProjection _projection = new();
@@ -171,7 +171,7 @@ public class TestRegisteredReaction : Reaction<TestView, TestCommand>
     }
 }
 
-[Reaction("AnotherReaction")]
+[Reaction("AnotherReaction", ["Test.Event.v1"])]
 public class AnotherRegisteredReaction : Reaction<TestView, TestCommand>
 {
     private readonly TestProjection _projection = new();

--- a/Rickten.Reactor.Tests/ReactionRunnerTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRunnerTests.cs
@@ -113,7 +113,7 @@ public class MembershipDefinitionProjection : Rickten.Projector.Projection<Membe
 /// <summary>
 /// Example reaction from the spec - now with projection-based stream selection
 /// </summary>
-[Reaction("MembershipDefinitionChanged", EventTypes = new[] { "MembershipDefinition.Changed.v1" })]
+[Reaction("MembershipDefinitionChanged", ["MembershipDefinition.Changed.v1"])]
 public sealed class MembershipDefinitionChangedReaction : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>
 {
     private readonly MembershipDefinitionProjection _projection = new();
@@ -150,7 +150,7 @@ public sealed class MembershipDefinitionChangedReaction : Reaction<MembershipDef
 /// <summary>
 /// Another example reaction for user registration - single stream case
 /// </summary>
-[Reaction("UserRegisteredReaction", EventTypes = new[] { "User.Registered.v1" })]
+[Reaction("UserRegisteredReaction", ["User.Registered.v1"])]
 public sealed class UserRegisteredReaction : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>
 {
     private readonly MembershipDefinitionProjection _projection = new();

--- a/Rickten.Reactor.Tests/ReactionRunnerTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRunnerTests.cs
@@ -36,13 +36,11 @@ public record MembershipState(string MembershipId, int CalculationCount);
 /// <summary>
 /// Test state folder
 /// </summary>
-public class MembershipStateFolder : StateFolder<MembershipState>
+public class MembershipStateFolder(EventStore.TypeMetadata.ITypeMetadataRegistry registry) : StateFolder<MembershipState>(registry)
 {
-    public MembershipStateFolder(EventStore.TypeMetadata.ITypeMetadataRegistry registry) : base(registry) { }
+    public override MembershipState InitialState() => new("", 0);
 
-    public override MembershipState InitialState() => new MembershipState("", 0);
-
-    protected MembershipState When(MembershipRecalculatedEvent e, MembershipState state)
+    protected static MembershipState When(MembershipRecalculatedEvent e, MembershipState state)
     {
         return state with { MembershipId = e.MembershipId, CalculationCount = state.CalculationCount + 1 };
     }
@@ -64,6 +62,7 @@ public class MembershipCommandDecider : CommandDecider<MembershipState, Recalcul
 /// Projection view that maps definition IDs to affected membership stream identifiers
 /// In a real system, this would query a read model to find memberships using a definition
 /// </summary>
+[Rickten.Projector.Projection("MembershipDefinitionView")]
 public record MembershipDefinitionView(Dictionary<string, List<string>> DefinitionToMemberships);
 
 /// <summary>
@@ -72,8 +71,7 @@ public record MembershipDefinitionView(Dictionary<string, List<string>> Definiti
 [Rickten.Projector.Projection("MembershipDefinitionIndex")]
 public class MembershipDefinitionProjection : Rickten.Projector.Projection<MembershipDefinitionView>
 {
-    public override MembershipDefinitionView InitialView() => 
-        new MembershipDefinitionView(new Dictionary<string, List<string>>());
+    public override MembershipDefinitionView InitialView() => new([]);
 
     protected override MembershipDefinitionView ApplyEvent(MembershipDefinitionView view, StreamEvent streamEvent)
     {
@@ -85,26 +83,27 @@ public class MembershipDefinitionProjection : Rickten.Projector.Projection<Membe
         };
     }
 
-    private MembershipDefinitionView AddDefinition(MembershipDefinitionView view, string definitionId)
+    private static MembershipDefinitionView AddDefinition(MembershipDefinitionView view, string definitionId)
     {
         var map = new Dictionary<string, List<string>>(view.DefinitionToMemberships);
         if (!map.ContainsKey(definitionId))
         {
-            map[definitionId] = new List<string>();
+            map[definitionId] = [];
         }
         return view with { DefinitionToMemberships = map };
     }
 
-    private MembershipDefinitionView AddMembershipToDefinition(MembershipDefinitionView view, string definitionId, string membershipId)
+    private static MembershipDefinitionView AddMembershipToDefinition(MembershipDefinitionView view, string definitionId, string membershipId)
     {
         var map = new Dictionary<string, List<string>>(view.DefinitionToMemberships);
-        if (!map.ContainsKey(definitionId))
+        if (!map.TryGetValue(definitionId, out List<string>? value))
         {
-            map[definitionId] = new List<string>();
+            value = [];
+            map[definitionId] = value;
         }
-        if (!map[definitionId].Contains(membershipId))
+        if (!value.Contains(membershipId))
         {
-            map[definitionId].Add(membershipId);
+            value.Add(membershipId);
         }
         return view with { DefinitionToMemberships = map };
     }
@@ -114,12 +113,10 @@ public class MembershipDefinitionProjection : Rickten.Projector.Projection<Membe
 /// Example reaction from the spec - now with projection-based stream selection
 /// </summary>
 [Reaction("MembershipDefinitionChanged", ["MembershipDefinition.Changed.v1"])]
-public sealed class MembershipDefinitionChangedReaction : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>
+public sealed class MembershipDefinitionChangedReaction(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
+    : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>(registry)
 {
     private readonly MembershipDefinitionProjection _projection = new();
-
-    public MembershipDefinitionChangedReaction(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
-        : base(registry) { }
 
     public override IProjection<MembershipDefinitionView> Projection => _projection;
 
@@ -151,12 +148,10 @@ public sealed class MembershipDefinitionChangedReaction : Reaction<MembershipDef
 /// Another example reaction for user registration - single stream case
 /// </summary>
 [Reaction("UserRegisteredReaction", ["User.Registered.v1"])]
-public sealed class UserRegisteredReaction : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>
+public sealed class UserRegisteredReaction(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
+    : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>(registry)
 {
     private readonly MembershipDefinitionProjection _projection = new();
-
-    public UserRegisteredReaction(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
-        : base(registry) { }
 
     public override IProjection<MembershipDefinitionView> Projection => _projection;
 
@@ -181,7 +176,7 @@ public sealed class UserRegisteredReaction : Reaction<MembershipDefinitionView, 
 /// </summary>
 public class InMemoryProjectionStore : IProjectionStore
 {
-    private readonly Dictionary<(string Namespace, string Key), object> _projections = new();
+    private readonly Dictionary<(string Namespace, string Key), object> _projections = [];
 
     public Task<EventStore.Projection<TState>?> LoadProjectionAsync<TState>(
         string projectionKey,
@@ -239,18 +234,17 @@ public class ReactionRunnerTests : IDisposable
 {
     private readonly Microsoft.Data.Sqlite.SqliteConnection _connection;
     private readonly IServiceProvider _serviceProvider;
-    private readonly InMemoryProjectionStore _projectionStore;
 
     public ReactionRunnerTests()
     {
         (_connection, _serviceProvider) = TestServiceFactory.CreateServiceProvider();
-        _projectionStore = new InMemoryProjectionStore();
     }
 
     public void Dispose()
     {
         _connection?.Dispose();
         (_serviceProvider as IDisposable)?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     [Fact]
@@ -265,35 +259,30 @@ public class ReactionRunnerTests : IDisposable
 
         // Create a definition
         var defStream = new StreamIdentifier("MembershipDefinition", "def-1");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-1", "Premium"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-1", "Premium"), null)
+        ]);
 
         // Register two users with this definition (creates memberships)
         var user1Stream = new StreamIdentifier("User", "user-1");
         var user2Stream = new StreamIdentifier("User", "user-2");
-        await eventStore.AppendAsync(new StreamPointer(user1Stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-1", "user1@test.com", "def-1"), null)
-        });
-        await eventStore.AppendAsync(new StreamPointer(user2Stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-2", "user2@test.com", "def-1"), null)
-        });
+        await eventStore.AppendAsync(user1Stream.At(0), [
+            new(new UserRegisteredEvent("user-1", "user1@test.com", "def-1"), null)
+        ]);
+        await eventStore.AppendAsync(user2Stream.At(0), [
+            new(new UserRegisteredEvent("user-2", "user2@test.com", "def-1"), null)
+        ]);
 
         // Change the definition again - this should trigger commands to both membership streams
-        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-1", "Premium Plus"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(1), [
+            new(new MembershipDefinitionChangedEvent("def-1", "Premium Plus"), null)
+        ]);
 
         // Act
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        var lastPosition = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        var lastPosition = await runner.CatchUpAsync(
             reaction,
             executor);
 
@@ -301,19 +290,21 @@ public class ReactionRunnerTests : IDisposable
         Assert.True(lastPosition > 0);
 
         // Verify checkpoint was saved
-        var checkpoint = _projectionStore.GetCheckpoint("MembershipDefinitionChanged");
-        Assert.Equal(lastPosition, checkpoint);
+        var reactionRepository = _serviceProvider.GetRequiredService<IReactionRepository>();
+        var savedCheckpoint = await reactionRepository.LoadCheckpointAsync("MembershipDefinitionChanged");
+        Assert.NotNull(savedCheckpoint);
+        Assert.Equal(lastPosition, savedCheckpoint.TriggerPosition);
 
         // Verify commands were executed against both membership streams
         var membership1Stream = new StreamIdentifier("Membership", "user-1");
-        var membership1Events = new List<StreamEvent>();
+        List<StreamEvent> membership1Events = [];
         await foreach (var evt in eventStore.LoadAsync(membership1Stream, CancellationToken.None))
         {
             membership1Events.Add(evt);
         }
 
         var membership2Stream = new StreamIdentifier("Membership", "user-2");
-        var membership2Events = new List<StreamEvent>();
+        List<StreamEvent> membership2Events = [];
         await foreach (var evt in eventStore.LoadAsync(membership2Stream, CancellationToken.None))
         {
             membership2Events.Add(evt);
@@ -336,42 +327,35 @@ public class ReactionRunnerTests : IDisposable
 
         // Create initial definition and user
         var defStream = new StreamIdentifier("MembershipDefinition", "def-2");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-2", "Basic"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-2", "Basic"), null)
+        ]);
 
         var userStream = new StreamIdentifier("User", "user-3");
-        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-3", "user3@test.com", "def-2"), null)
-        });
+        await eventStore.AppendAsync(userStream.At(0), [
+            new(new UserRegisteredEvent("user-3", "user3@test.com", "def-2"), null)
+        ]);
 
         // First definition change
-        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-2", "Standard"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(1), [
+            new(new MembershipDefinitionChangedEvent("def-2", "Standard"), null)
+        ]);
 
         // First catch-up
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        var firstPosition = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        var firstPosition = await runner.CatchUpAsync(
             reaction,
             executor);
 
         // Add another definition change
-        await eventStore.AppendAsync(new StreamPointer(defStream, 2), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-2", "Premium"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(2), [
+            new(new MembershipDefinitionChangedEvent("def-2", "Premium"), null)
+        ]);
 
         // Second catch-up
-        var secondPosition = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var secondPosition = await runner.CatchUpAsync(
             reaction,
             executor);
 
@@ -380,7 +364,7 @@ public class ReactionRunnerTests : IDisposable
 
         // Verify only 2 commands total (one for each definition change that matched)
         var membershipStream = new StreamIdentifier("Membership", "user-3");
-        var events = new List<StreamEvent>();
+        List<StreamEvent> events = [];
         await foreach (var evt in eventStore.LoadAsync(membershipStream, CancellationToken.None))
         {
             events.Add(evt);
@@ -401,30 +385,26 @@ public class ReactionRunnerTests : IDisposable
 
         // Create definition
         var defStream = new StreamIdentifier("MembershipDefinition", "def-3");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-3", "Gold"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-3", "Gold"), null)
+        ]);
 
         // Register user (this builds the projection mapping)
         var userStream = new StreamIdentifier("User", "user-4");
-        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-4", "user4@test.com", "def-3"), null)
-        });
+        await eventStore.AppendAsync(userStream.At(0), [
+            new(new UserRegisteredEvent("user-4", "user4@test.com", "def-3"), null)
+        ]);
 
         // Another definition change - this should now find the user and trigger a command
-        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-3", "Platinum"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(1), [
+            new(new MembershipDefinitionChangedEvent("def-3", "Platinum"), null)
+        ]);
 
         // Act - MembershipDefinitionChangedReaction only triggers on MembershipDefinition.Changed events
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        var lastPosition = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        var _ = await runner.CatchUpAsync(
             reaction,
             executor);
 
@@ -433,7 +413,7 @@ public class ReactionRunnerTests : IDisposable
         // Second definition change: 1 membership found (1 command)
         // Total: 1 command executed
         var membershipStream = new StreamIdentifier("Membership", "user-4");
-        var events = new List<StreamEvent>();
+        List<StreamEvent> events = [];
         await foreach (var evt in eventStore.LoadAsync(membershipStream, CancellationToken.None))
         {
             events.Add(evt);
@@ -455,38 +435,36 @@ public class ReactionRunnerTests : IDisposable
 
         // Create events
         var defStream = new StreamIdentifier("MembershipDefinition", "def-4");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-4", "Platinum"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-4", "Platinum"), null)
+        ]);
 
         var userStream = new StreamIdentifier("User", "user-2");
-        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-2", "user@test.com", "def-4"), null)
-        });
+        await eventStore.AppendAsync(userStream.At(0), [
+            new(new UserRegisteredEvent("user-2", "user@test.com", "def-4"), null)
+        ]);
 
         // Act - run both reactions
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        var pos1 = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        await runner.CatchUpAsync(
             reaction1,
             executor);
 
-        var pos2 = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        await runner.CatchUpAsync(
             reaction2,
             executor);
 
         // Assert - both should have processed their respective events
-        var checkpoint1 = _projectionStore.GetCheckpoint("MembershipDefinitionChanged");
-        var checkpoint2 = _projectionStore.GetCheckpoint("UserRegisteredReaction");
+        var reactionRepository = _serviceProvider.GetRequiredService<IReactionRepository>();
+        var checkpoint1 = await reactionRepository.LoadCheckpointAsync("MembershipDefinitionChanged");
+        var checkpoint2 = await reactionRepository.LoadCheckpointAsync("UserRegisteredReaction");
 
-        Assert.True(checkpoint1 > 0);
-        Assert.True(checkpoint2 > 0);
+        Assert.NotNull(checkpoint1);
+        Assert.True(checkpoint1.TriggerPosition > 0);
+        Assert.NotNull(checkpoint2);
+        Assert.True(checkpoint2.TriggerPosition > 0);
         // Checkpoints may differ based on event ordering
     }
 
@@ -522,23 +500,20 @@ public class ReactionRunnerTests : IDisposable
 
         // Create definition and user
         var defStream = new StreamIdentifier("MembershipDefinition", "def-rebuild");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-rebuild", "v1"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-rebuild", "v1"), null)
+        ]);
 
         var userStream = new StreamIdentifier("User", "user-rebuild");
-        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-rebuild", "user@test.com", "def-rebuild"), null)
-        });
+        await eventStore.AppendAsync(userStream.At(0), [
+            new(new UserRegisteredEvent("user-rebuild", "user@test.com", "def-rebuild"), null)
+        ]);
 
         // Create more definition changes
-        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-rebuild", "v2"), null),
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-rebuild", "v3"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(1), [
+            new(new MembershipDefinitionChangedEvent("def-rebuild", "v2"), null),
+            new(new MembershipDefinitionChangedEvent("def-rebuild", "v3"), null)
+        ]);
 
         // Simulate scenario: projection caught up to end, but reaction only processed first trigger
         // Manually set projection ahead of reaction
@@ -546,24 +521,26 @@ public class ReactionRunnerTests : IDisposable
         var firstTriggerPosition = 1L; // After first definition change
 
         // Build full projection state (as if it was caught up)
-        var fullView = new MembershipDefinitionView(new Dictionary<string, List<string>>());
+        var fullView = new MembershipDefinitionView([]);
         fullView = new MembershipDefinitionProjection().Apply(fullView, 
             new StreamEvent(new StreamPointer(defStream, 1), 1, 
-                new MembershipDefinitionChangedEvent("def-rebuild", "v1"), Array.Empty<EventMetadata>()));
+                new MembershipDefinitionChangedEvent("def-rebuild", "v1"), []));
         fullView = new MembershipDefinitionProjection().Apply(fullView,
             new StreamEvent(new StreamPointer(userStream, 1), 2,
-                new UserRegisteredEvent("user-rebuild", "user@test.com", "def-rebuild"), Array.Empty<EventMetadata>()));
+                new UserRegisteredEvent("user-rebuild", "user@test.com", "def-rebuild"), []));
 
         // Save checkpoints: projection ahead, reaction behind
-        await _projectionStore.SaveProjectionAsync("MembershipDefinitionChanged:trigger", firstTriggerPosition, firstTriggerPosition, "reaction");
-        await _projectionStore.SaveProjectionAsync("MembershipDefinitionChanged:projection", allEventsPosition, fullView, "reaction");
+        var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var reactionRepository = _serviceProvider.GetRequiredService<IReactionRepository>();
+        await reactionRepository.SaveCheckpointAsync(
+            new ReactionCheckpoint("MembershipDefinitionChanged", firstTriggerPosition, allEventsPosition));
+        await projectionStore.SaveProjectionAsync("MembershipDefinitionChanged:projection", allEventsPosition, fullView, "reaction");
 
         // Act - catch up should rebuild projection to reaction position (1), then process triggers 2-3
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        var finalPosition = await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        var finalPosition = await runner.CatchUpAsync(
             reaction,
             executor);
 
@@ -572,7 +549,7 @@ public class ReactionRunnerTests : IDisposable
 
         // Verify commands were executed for triggers 2 and 3
         var membershipStream = new StreamIdentifier("Membership", "user-rebuild");
-        var events = new List<StreamEvent>();
+        List<StreamEvent> events = [];
         await foreach (var evt in eventStore.LoadAsync(membershipStream, CancellationToken.None))
         {
             events.Add(evt);
@@ -593,7 +570,7 @@ public class ReactionRunnerTests : IDisposable
         var decider = new MembershipCommandDecider();
 
         // Create a simple logger that captures log messages
-        var logMessages = new List<string>();
+        List<string> logMessages = [];
         var loggerFactory = LoggerFactory.Create(builder => 
         {
             builder.AddProvider(new TestLoggerProvider(logMessages));
@@ -602,30 +579,37 @@ public class ReactionRunnerTests : IDisposable
 
         // Create definition
         var defStream = new StreamIdentifier("MembershipDefinition", "def-log");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-log", "v1"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-log", "v1"), null)
+        ]);
 
         // Simulate projection ahead scenario
-        await _projectionStore.SaveProjectionAsync("MembershipDefinitionChanged:trigger", 0, 0L, "reaction");
-        await _projectionStore.SaveProjectionAsync("MembershipDefinitionChanged:projection", 10, 
-            new MembershipDefinitionView(new Dictionary<string, List<string>>()), "reaction");
+        var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var reactionRepository = _serviceProvider.GetRequiredService<IReactionRepository>();
+        await reactionRepository.SaveCheckpointAsync(
+            new ReactionCheckpoint("MembershipDefinitionChanged", 0, 10));
+        await projectionStore.SaveProjectionAsync("MembershipDefinitionChanged", 10,
+            new MembershipDefinitionView([]), "reaction");
 
         // Act
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
-            reaction,
-            executor,
-            logger: logger);
 
-        // Assert - verify warning was logged
+        // Create runner with test logger
+        var testRunner = new ReactionRunner(
+            eventStore,
+            projectionStore,
+            reactionRepository,
+            loggerFactory.CreateLogger<ReactionRunner>());
+
+        await testRunner.CatchUpAsync(
+            reaction,
+            executor);
+
+        // Assert - verify warning was logged with useful details
         Assert.Contains(logMessages, msg => 
-            msg.Contains("projection is ahead of reaction checkpoint") &&
-            msg.Contains("Rebuilding projection"));
+            msg.Contains("projection drift detected") && 
+            msg.Contains("Rebuilding projection from scratch"));
     }
 
     [Fact]
@@ -640,36 +624,32 @@ public class ReactionRunnerTests : IDisposable
 
         // Create definition
         var defStream = new StreamIdentifier("MembershipDefinition", "def-metadata");
-        await eventStore.AppendAsync(new StreamPointer(defStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-metadata", "Premium"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(0), [
+            new(new MembershipDefinitionChangedEvent("def-metadata", "Premium"), null)
+        ]);
 
         // Register user with this definition
         var userStream = new StreamIdentifier("User", "user-metadata");
-        await eventStore.AppendAsync(new StreamPointer(userStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new UserRegisteredEvent("user-metadata", "user@test.com", "def-metadata"), null)
-        });
+        await eventStore.AppendAsync(userStream.At(0), [
+            new(new UserRegisteredEvent("user-metadata", "user@test.com", "def-metadata"), null)
+        ]);
 
         // Change the definition - this should trigger a command
-        await eventStore.AppendAsync(new StreamPointer(defStream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new MembershipDefinitionChangedEvent("def-metadata", "Premium Plus"), null)
-        });
+        await eventStore.AppendAsync(defStream.At(1), [
+            new(new MembershipDefinitionChangedEvent("def-metadata", "Premium Plus"), null)
+        ]);
 
         // Act
         var AggregateRepository = new AggregateRepository<MembershipState>(eventStore, folder, NoOpSnapshotStore.Instance);
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
-        await ReactionRunner.CatchUpAsync(
-            eventStore,
-            _projectionStore,
+        var runner = _serviceProvider.GetRequiredService<ReactionRunner>();
+        await runner.CatchUpAsync(
             reaction,
             executor);
 
         // Assert - verify reaction-produced events have ReactionWireName metadata
         var membershipStream = new StreamIdentifier("Membership", "user-metadata");
-        var events = new List<StreamEvent>();
+        List<StreamEvent> events = [];
         await foreach (var evt in eventStore.LoadAsync(membershipStream, CancellationToken.None))
         {
             events.Add(evt);
@@ -684,7 +664,6 @@ public class ReactionRunnerTests : IDisposable
         Assert.Equal("Reaction.MembershipDefinitionChanged.MembershipDefinitionChangedReaction", reactionWireName);
 
         // Also verify CorrelationId and CausationId are propagated
-        var correlationId = reactionEvent.Metadata.GetCorrelationId();
         var causationId = reactionEvent.Metadata.GetCausationId();
 
         // CausationId should be set to the trigger event's EventId
@@ -693,46 +672,36 @@ public class ReactionRunnerTests : IDisposable
 }
 
 // Simple test logger for capturing log messages
-public class TestLoggerProvider : ILoggerProvider
+public class TestLoggerProvider(List<string> messages) : ILoggerProvider
 {
-    private readonly List<string> _messages;
-
-    public TestLoggerProvider(List<string> messages)
+    public ILogger CreateLogger(string categoryName) => new TestLogger(messages);
+    public void Dispose()
     {
-        _messages = messages;
+        GC.SuppressFinalize(this);
     }
-
-    public ILogger CreateLogger(string categoryName) => new TestLogger(_messages);
-    public void Dispose() { }
 }
 
-public class TestLogger : ILogger
+public class TestLogger(List<string> messages) : ILogger
 {
-    private readonly List<string> _messages;
-
-    public TestLogger(List<string> messages)
-    {
-        _messages = messages;
-    }
-
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
     public bool IsEnabled(LogLevel logLevel) => true;
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        _messages.Add(formatter(state, exception));
+        if (IsEnabled(logLevel))
+        {
+            messages.Add(formatter(state, exception));
+        }
     }
 }
 
 /// <summary>
 /// Test reaction without attribute to verify error handling
 /// </summary>
-public class TestReactionWithoutAttribute : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>
+public class TestReactionWithoutAttribute(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
+    : Reaction<MembershipDefinitionView, RecalculateMembershipCommand>(registry)
 {
     private readonly MembershipDefinitionProjection _projection = new();
-
-    public TestReactionWithoutAttribute(EventStore.TypeMetadata.ITypeMetadataRegistry registry) 
-        : base(registry) { }
 
     public override IProjection<MembershipDefinitionView> Projection => _projection;
 

--- a/Rickten.Reactor.Tests/ServiceCollectionExtensionsTests.cs
+++ b/Rickten.Reactor.Tests/ServiceCollectionExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace Rickten.Reactor.Tests;
 public class ServiceCollectionExtensionsTests
 {
     // Test reaction classes
-    [Reaction("TestReaction1")]
+    [Reaction("TestReaction1", ["Test.Event.v1"])]
     public class TestReaction1 : Reaction<TestView, TestCommand>
     {
         public TestReaction1(ITypeMetadataRegistry registry) : base(registry) { }
@@ -29,7 +29,7 @@ public class ServiceCollectionExtensionsTests
         }
     }
 
-    [Reaction("TestReaction2")]
+    [Reaction("TestReaction2", ["Test.Event.v1"])]
     public class TestReaction2 : Reaction<TestView, TestCommand>
     {
         public TestReaction2(ITypeMetadataRegistry registry) : base(registry) { }
@@ -66,7 +66,7 @@ public class ServiceCollectionExtensionsTests
     }
 
     // Abstract reaction - should not be registered
-    [Reaction("AbstractReaction")]
+    [Reaction("AbstractReaction", ["Test.Event.v1"])]
     public abstract class AbstractReaction : Reaction<TestView, TestCommand>
     {
         protected AbstractReaction(ITypeMetadataRegistry registry) : base(registry) { }

--- a/Rickten.Reactor.Tests/TestServiceFactory.cs
+++ b/Rickten.Reactor.Tests/TestServiceFactory.cs
@@ -32,6 +32,9 @@ public static class TestServiceFactory
             options.UseSqlite(connection);
         }, typeof(TestServiceFactory).Assembly);
 
+        // Register reactions (also registers ReactionRunner)
+        services.AddReactions(typeof(TestServiceFactory).Assembly);
+
         var serviceProvider = services.BuildServiceProvider();
 
         // Create the database schema

--- a/Rickten.Reactor/README.md
+++ b/Rickten.Reactor/README.md
@@ -148,33 +148,63 @@ This ensures uniqueness even when multiple reactions share a logical name.
 
 ### Runner
 
+`ReactionRunner` is an instance-based service that orchestrates reaction execution:
+
 ```csharp
-public static class ReactionRunner
+public sealed class ReactionRunner
 {
-    public static Task<long> CatchUpAsync<TState, TView, TCommand>(
+    public ReactionRunner(
         IEventStore eventStore,
-        IProjectionStore projectionStore,  // Stores reaction checkpoints in "reaction" namespace
+        IProjectionStore projectionStore,
+        IReactionRepository reactionRepository,
+        ILogger<ReactionRunner>? logger = null);
+
+    public Task<long> CatchUpAsync<TState, TView, TCommand>(
         Reaction<TView, TCommand> reaction,
-        IStateFolder<TState> folder,
-        ICommandDecider<TState, TCommand> decider,
-        ISnapshotStore? snapshotStore = null,
-        string? reactionName = null,
-        ILogger? logger = null,  // Optional logging
+        AggregateCommandExecutor<TState, TCommand> executor,
         CancellationToken cancellationToken = default);
 }
 ```
 
-**Optional logging**: Pass an `ILogger` to receive diagnostic information:
+**Automatic logging**: The runner accepts an `ILogger<ReactionRunner>` in its constructor for diagnostic information:
 - ⚠️ **Warning**: When projection is ahead of reaction (indicates failure/recovery scenario)
-- ℹ️ **Info**: When projection is rebuilt for historical accuracy
+- 🔴 **Critical**: When event metadata is missing (CorrelationId or EventId)
+
+**Dependency Injection**: `ReactionRunner` is automatically registered as a singleton when calling `AddReactions`:
+
+```csharp
+services.AddReactions<MyReaction>();
+
+// ReactionRunner is now available for injection
+public class MyService
+{
+    private readonly ReactionRunner _runner;
+
+    public MyService(ReactionRunner runner)
+    {
+        _runner = runner;
+    }
+}
+```
 
 ### Checkpoint Storage
 
-Reactions use `IProjectionStore` with the `"reaction"` namespace to store:
-- **Reaction checkpoint** (`{reactionName}:trigger`) - Last trigger event processed
-- **Projection checkpoint** (`{reactionName}:projection`) - Last event applied to reaction's private projection
+Reactions use two separate storage mechanisms:
 
-This enables sharing the same database infrastructure with public projections (which use the `"system"` namespace) while maintaining logical separation.
+1. **`IReactionRepository`** - Stores execution checkpoints:
+   - Reaction name
+   - Trigger position (last processed trigger event)
+   - Projection position (how far projection was caught up)
+
+2. **`IProjectionStore`** (with `"reaction"` namespace) - Stores projection view state:
+   - Reaction name as key
+   - Materialized projection view
+   - Global position
+
+This separation enables:
+- ✅ Independent checkpoint management
+- ✅ Efficient projection catch-up on drift
+- ✅ Shared infrastructure with public projections (different namespace)
 
 ## Example
 
@@ -253,61 +283,168 @@ public sealed class MembershipDefinitionChangedReaction
 
 ## Execution Model
 
-`ReactionRunner.CatchUpAsync` behavior:
+`ReactionRunner.CatchUpAsync` orchestrates the following:
 
-1. **Load checkpoints** from `IProjectionStore` (using "reaction" namespace):
-   - Reaction checkpoint (`{name}:trigger`): last trigger event successfully processed
-   - Projection checkpoint (`{name}:projection`): last event applied to reaction's private projection
-2. **Read events** from `IEventStore.LoadAllAsync`:
-   - Start from `Min(reactionPosition, projectionPosition)`
-   - Use projection's aggregate/event type filters for efficiency
-3. **For each event**:
-   - **Always** apply projection events (respecting projection filters) if newer than projection checkpoint
-   - **If event is a trigger** (matches `EventTypeFilter` and newer than reaction checkpoint):
-     - Call `reaction.SelectStreams(projectionView, trigger)` to get target streams
-     - For each selected stream:
-       - Call `reaction.BuildCommand(stream, projectionView, trigger)`
-       - Execute command through `StateRunner.ExecuteAsync`
-     - **After all commands succeed**, save both checkpoints
-4. **Return** final processed position
+1. **Load checkpoints**:
+   - Reaction checkpoint from `IReactionRepository` (trigger and projection positions)
+   - Projection view from `IProjectionStore` (using "reaction" namespace)
+2. **Synchronize projection** to reaction position if drift detected:
+   - If projection ahead: Rebuild from scratch to reaction position
+   - If projection behind: Catch up from checkpoint to reaction position
+   - Uses `ProjectionRunner.SyncToPositionAsync` internally
+3. **Process new events** from `IEventStore.LoadAllAsync`:
+   - Merge projection events and trigger events by global position
+   - Apply projection events to update view incrementally
+4. **For each trigger event**:
+   - Call `reaction.SelectStreams(projectionView, trigger)` to get target streams
+   - For each selected stream:
+     - Call `reaction.BuildCommand(stream, projectionView, trigger)`
+     - Execute command through `AggregateCommandExecutor`
+   - Save reaction checkpoint after all commands succeed
+5. **Save final checkpoint** with updated positions
 
 ### Reaction-Owned Projection State
 
-**Key insight**: Each reaction maintains its **own private projection state**, stored in `IProjectionStore` using the `"reaction"` namespace.
+**Key insight**: Each reaction maintains its **own private projection state**, stored separately from the reaction checkpoint.
 
-- **Public projections**: Use `ProjectionRunner.CatchUpAsync(eventStore, publicProjectionStore, projection, ...)` with default `"system"` namespace
-- **Reaction projections**: The reaction uses the same `IProjection<TView>` but stores state in the `"reaction"` namespace
+- **`IReactionRepository`**: Stores execution state (trigger position, projection position)
+- **`IProjectionStore`** (reaction namespace): Stores the materialized projection view
+- **Public projections**: Use `ProjectionRunner.CatchUpAsync` with "system" namespace
+- **Reaction projections**: Same `IProjection<TView>` interface but stored in "reaction" namespace
 
 **Benefits:**
-- ✅ No API pollution - `ProjectionRunner` stays clean
-- ✅ No dangerous methods to misuse
+- ✅ Clean separation - checkpoint positions vs view state
 - ✅ Performance - projection filters work normally
 - ✅ Independence - public and reaction projections have separate lifecycles
-- ✅ Simplicity - projection state is managed transparently by the runner
-- ✅ Shared infrastructure - same database table, separated by namespace
+- ✅ Simplicity - projection state managed transparently by the runner
+- ✅ Shared infrastructure - same database, different namespace
 
 **The projection view always represents deterministic state** because:
-1. It's caught up incrementally as events stream in
-2. When a trigger event is processed, the projection already reflects all prior events
-3. The view naturally represents state "up to and including" the trigger event
+1. It's synchronized to the reaction position before processing begins
+2. When a trigger event is processed, the projection reflects all prior events
+3. The view represents state "up to and including" the trigger event
 
 ## Checkpoint Semantics
 
-**Two checkpoints per reaction:**
+**Separate checkpoint storage:**
 
-1. **Reaction checkpoint**: Last trigger event successfully processed
-   - Advances only after **all** commands for a trigger succeed
-   - If any command fails, reaction checkpoint is **not** saved
+1. **Reaction checkpoint** (in `IReactionRepository`):
+   - Stores: Reaction name, trigger position, projection position
+   - Saved after **all** commands for a trigger succeed
+   - If any command fails, checkpoint is **not** saved
 
-2. **Projection checkpoint**: Last event applied to reaction's private projection
-   - Advances as events are applied to the projection
-   - Saved when reaction checkpoint is saved (kept in sync)
-   - Enables efficient catch-up (don't rebuild projection from scratch)
+2. **Projection view** (in `IProjectionStore` with "reaction" namespace):
+   - Stores: Materialized projection state at a specific position
+   - Saved during sync step by `ProjectionRunner.SyncToPositionAsync`
+   - Not saved after each trigger (sync handles it on restart if needed)
 
 **Guarantees:**
 - At-least-once delivery (trigger events may be reprocessed after failure)
 - Commands **must be idempotent** (replay may occur after partial execution)
-- Projection state is always consistent with or ahead of reaction progress
+- Projection state can be behind reaction checkpoint (sync catches it up on startup)
+
+## At-Least-Once Delivery and Idempotency
+
+**⚠️ Critical: Commands produced by reactions may be executed multiple times.**
+
+Reactions provide **at-least-once delivery** semantics:
+- If a reaction crashes after executing some commands but before saving its checkpoint, those commands will be re-executed on restart
+- If a command execution fails partway through a batch, the entire batch may be retried
+- Network failures, process restarts, or exceptions can all trigger re-execution
+
+### Required: Idempotent Command Design
+
+**All commands executed by reactions MUST be idempotent.** This means:
+
+✅ **Safe to execute multiple times with the same result**
+```csharp
+// Good: Set absolute state
+new UpdateUserStatus(userId, status: "Active");
+
+// Good: Use conditional logic in decider
+if (state.Status != "Active") {
+    yield return new UserStatusChangedEvent(userId, "Active");
+}
+```
+
+❌ **NOT safe if dependent on execution count**
+```csharp
+// Bad: Increment counter (executes twice = wrong count)
+new IncrementCounter(userId);
+
+// Bad: Add to collection without deduplication
+new AddItem(userId, item);
+```
+
+### Design Strategies
+
+1. **Use absolute state commands** - Set values rather than apply deltas
+2. **Check current state in deciders** - Only emit events if state actually changes
+3. **Use correlation/causation IDs** - Detect and skip duplicate executions
+4. **Design aggregates for idempotency** - Make state transitions naturally idempotent
+
+### Example: Idempotent Recalculation
+
+```csharp
+// Command is safe to execute multiple times
+protected override RecalculateMembershipCommand BuildCommand(
+    StreamIdentifier stream,
+    MembershipDefinitionView view,
+    StreamEvent trigger)
+{
+    return new RecalculateMembershipCommand(
+        stream.Identifier,
+        definitionVersion: ((MembershipDefinitionChangedEvent)trigger.Event).Version);
+}
+
+// Decider checks version before emitting events
+public IEnumerable<object> Decide(MembershipState state, RecalculateMembershipCommand command)
+{
+    // Only recalculate if definition version has actually changed
+    if (state.DefinitionVersion == command.DefinitionVersion)
+    {
+        yield break; // Already processed this version
+    }
+
+    yield return new MembershipRecalculatedEvent(
+        state.MembershipId,
+        command.DefinitionVersion,
+        newValue: CalculateValue(state, command));
+}
+```
+
+### Checkpoint Recovery
+
+On startup after a crash:
+1. **Sync step** detects if projection is behind reaction checkpoint
+2. **Projection is caught up** to reaction position using `ProjectionRunner`
+3. **Reaction resumes** from last saved checkpoint
+4. **Unconfirmed triggers are reprocessed** - commands may execute again
+
+This is why idempotency is non-negotiable.
+
+### Projection Checkpoint Frequency
+
+**Projection state is only saved during the sync step, not after processing each trigger.**
+
+If a reaction crashes mid-processing:
+- Reaction checkpoint remains at the last successfully processed trigger
+- Projection checkpoint may be behind (not saved yet)
+- On restart, the sync step catches up the projection before processing resumes
+
+**Performance consideration**: The sync step rebuilds or catches up the projection to match the reaction checkpoint. For reactions that process many projection events between triggers:
+
+💡 **Recommendation**: Configure your `IProjectionStore` implementation with a **batch size of 1** for reaction projections (those in the "reaction" namespace). This ensures projection checkpoints are saved frequently during the sync step, minimizing the amount of work needed on recovery.
+
+Example with Entity Framework implementation:
+```csharp
+services.AddProjectionStore(options => 
+{
+    options.BatchSize = 1; // Save after every event during sync
+});
+```
+
+This trades a small amount of write throughput for faster crash recovery and more granular checkpointing.
 
 ## Metadata Propagation
 
@@ -395,10 +532,11 @@ This keeps reactions simple and composable.
 ## Philosophy
 
 Rickten.Reactor follows Rickten's design principles:
-- **Small primitives**: Base class, attribute, runner, store
+- **Small primitives**: Base class, attribute, runner service, repositories
 - **Explicit dependencies**: Reaction owns its projection
-- **Static runners**: `ReactionRunner` is a static utility; reactions themselves can be DI-registered
-- **Explicit persistence**: `IProjectionStore` interface with `"reaction"` namespace
+- **Instance-based runner**: `ReactionRunner` is a DI-registered service with injected dependencies
+- **Separate checkpoint concerns**: `IReactionRepository` for positions, `IProjectionStore` for views
+- **Explicit persistence**: Clear interfaces with namespace separation
 - **No hosting concerns**: Mechanism, not framework
 
-A future hosting/daemon project may call `ReactionRunner.CatchUpAsync` repeatedly, but that is out of scope for Rickten.Reactor itself.
+`Rickten.Runtime` provides hosted services that call `ReactionRunner.CatchUpAsync` repeatedly in polling loops.

--- a/Rickten.Reactor/Reaction.cs
+++ b/Rickten.Reactor/Reaction.cs
@@ -51,9 +51,9 @@ public abstract class Reaction<TView, TCommand>
     public string? WireName => _reactionInfo.WireName;
 
     /// <summary>
-    /// Gets the event type filter from the [Reaction] attribute, if configured.
+    /// Gets the event type filter from the [Reaction] attribute.
     /// </summary>
-    public string[]? EventTypeFilter => _reactionInfo.EventTypes;
+    public string[] EventTypeFilter => _reactionInfo.EventTypes;
 
     /// <summary>
     /// Gets the projection used to identify affected aggregate streams.
@@ -81,26 +81,18 @@ public abstract class Reaction<TView, TCommand>
 
     /// <summary>
     /// Determines if an event should trigger this reaction.
-    /// Default implementation checks event type against EventTypeFilter if configured.
+    /// Default implementation checks event type against EventTypeFilter.
     /// Override to add custom filtering logic.
     /// </summary>
     /// <param name="streamEvent">The event to evaluate.</param>
     /// <returns>True if the event should trigger this reaction.</returns>
     protected virtual bool ShouldProcess(StreamEvent streamEvent)
     {
-        // If no filter is configured, process all events
-        if (EventTypeFilter == null || EventTypeFilter.Length == 0)
-        {
-            return true;
-        }
-
-        // Get the wire type name from the event using [Event] attribute
         var eventType = streamEvent.Event.GetType();
         var eventAttr = eventType.GetCustomAttribute<EventStore.EventAttribute>();
 
         if (eventAttr == null)
         {
-            // No attribute - can't match filter
             return false;
         }
 
@@ -133,4 +125,4 @@ public abstract class Reaction<TView, TCommand>
 /// <summary>
 /// Internal record to hold reaction metadata.
 /// </summary>
-internal sealed record ReactionInfo(string Name, string[]? EventTypes, string? WireName);
+internal sealed record ReactionInfo(string Name, string[] EventTypes, string? WireName);

--- a/Rickten.Reactor/Reaction.cs
+++ b/Rickten.Reactor/Reaction.cs
@@ -42,7 +42,7 @@ public abstract class Reaction<TView, TCommand>
     /// <summary>
     /// Gets the reaction name from the [Reaction] attribute.
     /// </summary>
-    public string ReactionName => _reactionInfo.Name;
+    public string Name => _reactionInfo.Name;
 
     /// <summary>
     /// Gets the wire name of this reaction.

--- a/Rickten.Reactor/ReactionAttribute.cs
+++ b/Rickten.Reactor/ReactionAttribute.cs
@@ -3,24 +3,27 @@ using Rickten.EventStore.TypeMetadata;
 namespace Rickten.Reactor;
 
 /// <summary>
-/// Optional attribute for reaction metadata and event filtering.
-/// Used to optimize event queries by filtering at the store level.
+/// Attribute for reaction metadata and event filtering.
 /// </summary>
 /// <param name="name">The reaction name (used for checkpointing and identification).</param>
+/// <param name="eventTypes">The event types this reaction triggers on. Used to filter events at the store level via LoadAllAsync.</param>
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-public sealed class ReactionAttribute(string name) : Attribute, ITypeMetadata
+public sealed class ReactionAttribute(string name, string[] eventTypes) : Attribute, ITypeMetadata
 {
     /// <summary>
     /// Gets the reaction name.
     /// </summary>
-    public string Name { get; } = name;
+    public string Name { get; } = !string.IsNullOrWhiteSpace(name)
+        ? name
+        : throw new ArgumentException("Reaction name cannot be null or whitespace.", nameof(name));
 
     /// <summary>
-    /// Gets or sets the event types this reaction triggers on.
+    /// Gets the event types this reaction triggers on.
     /// Used to filter events at the store level via LoadAllAsync.
-    /// If null, all event types are processed.
     /// </summary>
-    public string[]? EventTypes { get; init; }
+    public string[] EventTypes { get; } = eventTypes?.Length > 0
+        ? eventTypes
+        : throw new ArgumentException("Event types cannot be null or empty.", nameof(eventTypes));
 
     /// <summary>
     /// Gets or sets the polling interval in milliseconds for hosted reactions.

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -162,20 +162,18 @@ public sealed class ReactionRunner(IEventStore eventStore,
                 }
 
                 lastReactionPosition = streamEvent.GlobalPosition;
-                await _reactionRepository.SaveCheckpointAsync(
-                    new ReactionCheckpoint(reaction.Name, lastReactionPosition, projectionPosition),
-                    cancellationToken);
+
+                await SaveReactionStateAsync(reaction.Name, lastReactionPosition, projectionPosition, projectionView, cancellationToken);
             }
         }
 
-        await _reactionRepository.SaveCheckpointAsync(
-            new ReactionCheckpoint(reaction.Name, lastReactionPosition, projectionPosition),
-            cancellationToken);
+        // Final save to persist projection-only updates
+        await SaveReactionStateAsync(reaction.Name, lastReactionPosition, projectionPosition, projectionView, cancellationToken);
 
         return lastReactionPosition;
     }
 
-    private ReactionCheckpoint CreateInitialState(string reactionName)
+    private static ReactionCheckpoint CreateInitialState(string reactionName)
     {
         return new ReactionCheckpoint(
                 ReactionName: reactionName,
@@ -217,5 +215,26 @@ public sealed class ReactionRunner(IEventStore eventStore,
                                     streamEvent.GlobalPosition, streamEvent.StreamPointer.Stream);
             }
         }
+    }
+
+    /// <summary>
+    /// Saves both the reaction checkpoint and the projection view to keep them in sync.
+    /// </summary>
+    private async Task SaveReactionStateAsync<TView>(
+        string reactionName,
+        long triggerPosition,
+        long projectionPosition,
+        TView projectionView,
+        CancellationToken cancellationToken)
+    {
+        await _reactionRepository.SaveCheckpointAsync(
+            new ReactionCheckpoint(reactionName, triggerPosition, projectionPosition),
+            cancellationToken);
+        await _projectionStore.SaveProjectionAsync(
+            reactionName,
+            projectionPosition,
+            projectionView,
+            "reaction",
+            cancellationToken);
     }
 }

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -80,31 +80,15 @@ public static class ReactionRunner
         ILogger? logger = null,
         CancellationToken cancellationToken = default)
     {
-        // Reaction name is guaranteed by [Reaction] attribute (required constructor parameter)
-        // and validated during Reaction construction
-        var name = reaction.ReactionName;
+        var name                    = reaction.ReactionName;
+        var reactionCheckpoint      = await projectionStore.LoadProjectionAsync<long>($"{name}:trigger", "reaction", cancellationToken)
+                                            ?? new EventStore.Projection<long>(State: 0, GlobalPosition: 0);
+        var projectionCheckpoint    = await projectionStore.LoadProjectionAsync<TView>($"{name}:projection", "reaction", cancellationToken)
+                                            ?? new EventStore.Projection<TView>(State: reaction.Projection.InitialView(), GlobalPosition: 0);
 
-        // Load reaction checkpoint (last trigger event successfully processed)
-        // Stored as a projection with key "{reactionName}:trigger" in "reaction" namespace
-        var reactionCheckpoint = await projectionStore.LoadProjectionAsync<long>($"{name}:trigger", "reaction", cancellationToken);
-        var reactionPosition = reactionCheckpoint?.State ?? 0;
-
-        // Load reaction's private projection state
-        // Stored as a projection with key "{reactionName}:projection" in "reaction" namespace
-        var projectionCheckpoint = await projectionStore.LoadProjectionAsync<TView>($"{name}:projection", "reaction", cancellationToken);
-        TView projectionView;
-        long projectionPosition;
-
-        if (projectionCheckpoint != null)
-        {
-            projectionView = projectionCheckpoint.State;
-            projectionPosition = projectionCheckpoint.GlobalPosition;
-        }
-        else
-        {
-            projectionView = reaction.Projection.InitialView();
-            projectionPosition = 0;
-        }
+        var reactionPosition        = reactionCheckpoint.State;
+        var projectionView          = projectionCheckpoint.State;
+        var projectionPosition      = projectionCheckpoint.GlobalPosition;
 
         // Get projection filters if available for optimized event loading
         string[]? aggregateFilter = null;

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -56,13 +56,11 @@ public static class ReactionRunner
     /// <typeparam name="TCommand">The command type to execute against target aggregates.</typeparam>
     /// <param name="eventStore">The event store to load events from.</param>
     /// <param name="projectionStore">The projection store for managing checkpoints (reactions use "reaction" namespace).</param>
-    /// <param name="reaction">The reaction to execute. The reaction owns its projection via the <see cref="Reaction{TView,TCommand}.Projection"/> property.</param>
+    /// <param name="reaction">The reaction to execute. The reaction name from the [Reaction] attribute is used for checkpoint keys. The reaction owns its projection via the <see cref="Reaction{TView,TCommand}.Projection"/> property.</param>
     /// <param name="executor">The aggregate command executor for executing commands against target aggregates. The executor is configured with folder, decider, registry, and snapshot store for the target aggregate type.</param>
-    /// <param name="reactionName">The name to use for storing the reaction checkpoints (defaults to reaction's name from [Reaction] attribute).</param>
     /// <param name="logger">Optional logger for diagnostic information. Recommended for production to detect checkpoint drift and rebuild scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The global position of the last successfully processed trigger event.</returns>
-    /// <exception cref="ArgumentException">Thrown when reaction name cannot be determined from parameter or attribute.</exception>
     /// <remarks>
     /// <para>
     /// <strong>Projection Ownership:</strong> The reaction conceptually owns its projection. If the projection has
@@ -79,18 +77,12 @@ public static class ReactionRunner
         IProjectionStore projectionStore,
         Reaction<TView, TCommand> reaction,
         AggregateCommandExecutor<TState, TCommand> executor,
-        string? reactionName = null,
         ILogger? logger = null,
         CancellationToken cancellationToken = default)
     {
-        // Determine reaction name
-        var name = reactionName ?? reaction.ReactionName;
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentException(
-                "Reaction name must be provided either via parameter or [Reaction] attribute",
-                nameof(reactionName));
-        }
+        // Reaction name is guaranteed by [Reaction] attribute (required constructor parameter)
+        // and validated during Reaction construction
+        var name = reaction.ReactionName;
 
         // Load reaction checkpoint (last trigger event successfully processed)
         // Stored as a projection with key "{reactionName}:trigger" in "reaction" namespace

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -1,18 +1,17 @@
+using Microsoft.Extensions.Logging;
 using Rickten.Aggregator;
 using Rickten.EventStore;
 using Rickten.Projector;
-using System.Reflection;
-using Microsoft.Extensions.Logging;
 
 namespace Rickten.Reactor;
 
 /// <summary>
-/// Utilities for executing reactions using projection-based stream selection.
+/// Executes reactions using projection-based stream selection.
 /// <para>
-/// Each reaction maintains TWO checkpoints in the "reaction" namespace:
+/// Each reaction maintains TWO checkpoints:
 /// <list type="bullet">
-/// <item><description><c>{reactionName}:trigger</c> - Last trigger event fully reacted (commands executed and saved)</description></item>
-/// <item><description><c>{reactionName}:projection</c> - Last event applied to the private reaction projection</description></item>
+/// <item><description>Reaction checkpoint in <see cref="IReactionRepository"/> - Trigger and projection positions</description></item>
+/// <item><description>Projection view in <see cref="IProjectionStore"/> (reaction namespace) - The projection state</description></item>
 /// </list>
 /// </para>
 /// <para>
@@ -22,18 +21,29 @@ namespace Rickten.Reactor;
 /// </para>
 /// </summary>
 /// <remarks>
-/// Public projections use the "system" namespace and are managed by <see cref="Projector.ProjectionRunner"/>.
-/// Reaction projections are private and isolated in the "reaction" namespace.
+/// Initializes a new instance of the <see cref="ReactionRunner"/> class.
 /// </remarks>
-public static class ReactionRunner
+/// <param name="eventStore">The event store to load events from.</param>
+/// <param name="projectionStore">The projection store for managing projection state.</param>
+/// <param name="reactionRepository">The reaction repository for managing reaction checkpoints.</param>
+/// <param name="logger">Optional logger for diagnostic information.</param>
+public sealed class ReactionRunner(IEventStore eventStore,
+                                   IProjectionStore projectionStore,
+                                   IReactionRepository reactionRepository,
+                                   ILogger<ReactionRunner>? logger = null)
 {
+    private readonly IEventStore _eventStore = eventStore;
+    private readonly IProjectionStore _projectionStore = projectionStore;
+    private readonly IReactionRepository _reactionRepository = reactionRepository;
+    private readonly ILogger<ReactionRunner>? _logger = logger;
+
     /// <summary>
     /// Catches up a reaction from its last checkpoint.
     /// <para>
-    /// The reaction maintains its own private projection state for stream selection, storing two checkpoints:
+    /// The reaction maintains separate checkpoints for execution state and projection view:
     /// <list type="number">
-    /// <item><description><strong>Trigger checkpoint</strong> (<c>{reactionName}:trigger</c>): The global position of the last trigger event that was fully processed (all commands executed and saved).</description></item>
-    /// <item><description><strong>Projection checkpoint</strong> (<c>{reactionName}:projection</c>): The global position of the last event applied to the reaction's private projection view.</description></item>
+    /// <item><description><strong>Reaction checkpoint</strong> (in <see cref="IReactionRepository"/>): Stores trigger and projection positions for the reaction.</description></item>
+    /// <item><description><strong>Projection view</strong> (in <see cref="IProjectionStore"/> with "reaction" namespace): The materialized projection state at the projection position.</description></item>
     /// </list>
     /// </para>
     /// <para>
@@ -42,7 +52,7 @@ public static class ReactionRunner
     /// <item><description>Ensures the reaction's private projection represents state at the trigger's global position (historical accuracy)</description></item>
     /// <item><description>Selects target aggregate streams using the projection view</description></item>
     /// <item><description>Executes a command against each selected stream through the aggregator pipeline</description></item>
-    /// <item><description>Saves both checkpoints after all commands succeed (atomic commit)</description></item>
+    /// <item><description>Saves the reaction checkpoint after all commands succeed</description></item>
     /// </list>
     /// </para>
     /// <para>
@@ -54,11 +64,8 @@ public static class ReactionRunner
     /// <typeparam name="TState">The target aggregate state type.</typeparam>
     /// <typeparam name="TView">The projection view type used to select target streams.</typeparam>
     /// <typeparam name="TCommand">The command type to execute against target aggregates.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
-    /// <param name="projectionStore">The projection store for managing checkpoints (reactions use "reaction" namespace).</param>
     /// <param name="reaction">The reaction to execute. The reaction name from the [Reaction] attribute is used for checkpoint keys. The reaction owns its projection via the <see cref="Reaction{TView,TCommand}.Projection"/> property.</param>
     /// <param name="executor">The aggregate command executor for executing commands against target aggregates. The executor is configured with folder, decider, registry, and snapshot store for the target aggregate type.</param>
-    /// <param name="logger">Optional logger for diagnostic information. Recommended for production to detect checkpoint drift and rebuild scenarios.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The global position of the last successfully processed trigger event.</returns>
     /// <remarks>
@@ -72,114 +79,71 @@ public static class ReactionRunner
     /// are saved. Ensure commands are idempotent.
     /// </para>
     /// </remarks>
-    public static async Task<long> CatchUpAsync<TState, TView, TCommand>(
-        IEventStore eventStore,
-        IProjectionStore projectionStore,
+    public async Task<long> CatchUpAsync<TState, TView, TCommand>(
         Reaction<TView, TCommand> reaction,
         AggregateCommandExecutor<TState, TCommand> executor,
-        ILogger? logger = null,
         CancellationToken cancellationToken = default)
     {
-        var name                    = reaction.ReactionName;
-        var reactionCheckpoint      = await projectionStore.LoadProjectionAsync<long>($"{name}:trigger", "reaction", cancellationToken)
-                                            ?? new EventStore.Projection<long>(State: 0, GlobalPosition: 0);
-        var projectionCheckpoint    = await projectionStore.LoadProjectionAsync<TView>($"{name}:projection", "reaction", cancellationToken)
-                                            ?? new EventStore.Projection<TView>(State: reaction.Projection.InitialView(), GlobalPosition: 0);
+        var checkpoint = await _reactionRepository.LoadCheckpointAsync(reaction.Name, cancellationToken)
+            ?? CreateInitialState(reaction.Name);
 
-        var reactionPosition        = reactionCheckpoint.State;
-        var projectionView          = projectionCheckpoint.State;
-        var projectionPosition      = projectionCheckpoint.GlobalPosition;
+        var projectionCheckpoint = await _projectionStore.LoadProjectionAsync<TView>(reaction.Name, "reaction", cancellationToken);
 
-        // Get projection filters if available for optimized event loading
-        string[]? aggregateFilter = null;
-        string[]? eventTypeFilter = null;
-        if (reaction.Projection is Projector.Projection<TView> proj)
+
+        var projectionView = projectionCheckpoint != null ? projectionCheckpoint.State : reaction.Projection.InitialView();
+        var projectionPosition = projectionCheckpoint?.GlobalPosition ?? 0;
+        var reactionPosition = checkpoint.TriggerPosition;
+        var aggregateFilter = reaction.Projection.AggregateTypeFilter;
+        var eventTypeFilter = reaction.Projection.EventTypeFilter;
+
+        if (projectionPosition > reactionPosition && _logger?.IsEnabled(LogLevel.Warning) == true)
         {
-            aggregateFilter = proj.AggregateTypeFilter;
-            eventTypeFilter = proj.EventTypeFilter;
+            _logger.LogWarning(
+                "Reaction '{ReactionName}' projection drift detected. Projection is at position {ProjectionPosition} but reaction last ran at {ReactionPosition}. " +
+                "This may indicate the reaction checkpoint was reset or corrupted. Rebuilding projection from scratch to position {ReactionPosition}.",
+                reaction.Name, projectionPosition, reactionPosition, reactionPosition);
         }
 
-        // If projection is ahead of reaction, rebuild projection to reaction position
-        // This ensures projection represents correct historical state when processing old triggers
-        long fromPosition;
-        if (projectionPosition > reactionPosition)
-        {
-            // Log warning: projection being ahead indicates something unexpected happened
-            logger?.LogWarning(
-                "Reaction '{ReactionName}' projection is ahead of reaction checkpoint. " +
-                "Projection position: {ProjectionPosition}, Reaction position: {ReactionPosition}. " +
-                "Rebuilding projection from scratch to ensure historical accuracy. " +
-                "This may indicate a previous reaction failure or manual intervention.",
-                name, projectionPosition, reactionPosition);
+        (projectionView, projectionPosition) = await ProjectionRunner.SyncToPositionAsync(
+            _eventStore,
+            _projectionStore,
+            reaction.Projection,
+            projectionView,
+            projectionPosition,
+            reactionPosition,
+            reaction.Name,
+            "reaction",
+            cancellationToken);
 
-            // Rebuild projection up to reaction position using ProjectionRunner
-            (projectionView, projectionPosition) = await ProjectionRunner.RebuildUntilAsync(
-                eventStore,
-                reaction.Projection,
-                reactionPosition,
-                fromGlobalPosition: 0,
-                cancellationToken);
-
-            logger?.LogInformation(
-                "Reaction '{ReactionName}' projection rebuilt to position {ProjectionPosition}",
-                name, projectionPosition);
-
-            // Now start processing from reaction position
-            fromPosition = reactionPosition;
-        }
-        else
-        {
-            // Projection is behind or equal to reaction, start from projection position
-            fromPosition = projectionPosition;
-        }
 
         var lastReactionPosition = reactionPosition;
 
-        // Load two separate event streams:
-        // 1. Projection events (with projection's filters) - to keep projection state current
-        // 2. Trigger events (with reaction's filters) - to execute commands
-        // Merge them by global position for ordered processing
-
-        var mergedEvents = MergeEventStreamsByPosition(
-            eventStore.LoadAllAsync(fromPosition, aggregateFilter, eventTypeFilter, cancellationToken),
-            eventStore.LoadAllAsync(fromPosition, null, reaction.EventTypeFilter, cancellationToken),
+        var mergedEvents = _eventStore.LoadAllMergedAsync(
+            reactionPosition,
+            [
+                (aggregateFilter, eventTypeFilter),  // Filter 0: Projection events
+                (null, reaction.EventTypeFilter)     // Filter 1: Trigger events
+            ],
             cancellationToken);
 
-        await foreach (var (streamEvent, isProjectionEvent, isTriggerEvent) in mergedEvents)
+        await foreach (var (streamEvent, matchingFilters) in mergedEvents)
         {
-            // Update projection view if this is a projection event
+            bool isProjectionEvent = matchingFilters.Contains(0);
+            bool isTriggerEvent = matchingFilters.Contains(1);
+
             if (isProjectionEvent && streamEvent.GlobalPosition > projectionPosition)
             {
                 projectionView = reaction.Projection.Apply(projectionView, streamEvent);
                 projectionPosition = streamEvent.GlobalPosition;
             }
 
-            // Process trigger if this is a trigger event
             if (isTriggerEvent && streamEvent.GlobalPosition > reactionPosition)
             {
-                // Process trigger event with current projection view
                 var commands = reaction.Process(projectionView, streamEvent);
-
-                // Build metadata for outgoing commands from the trigger event
-                // Propagate CorrelationId value (will be tagged as Client source in reaction)
-                // Set CausationId to trigger's EventId
                 var reactionMetadata = new List<AppendMetadata>();
 
-                // Propagate CorrelationId value (source will be Client in reaction)
-                var triggerCorrelationId = streamEvent.Metadata.GetCorrelationId();
-                if (triggerCorrelationId != null)
-                {
-                    // Pass just the value - reaction will be tagged as Client source
-                    reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.CorrelationId, triggerCorrelationId));
-                }
-
-                // Set CausationId to the trigger event's system-generated EventId
-                // Use GetSystemEventId to ensure we're using the authoritative system EventId
-                var triggerEventId = streamEvent.Metadata.GetSystemEventId();
-                if (triggerEventId.HasValue)
-                {
-                    reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.CausationId, triggerEventId.Value));
-                }
+                AddCorrelationIdMetadata(streamEvent, reactionMetadata);
+                AddEventIdMetadata(streamEvent, reactionMetadata);
 
                 // Add reaction identity metadata
                 if (reaction.WireName != null)
@@ -197,76 +161,60 @@ public static class ReactionRunner
                         cancellationToken);
                 }
 
-                // Save both checkpoints after all commands for this trigger succeed
                 lastReactionPosition = streamEvent.GlobalPosition;
-                await projectionStore.SaveProjectionAsync($"{name}:trigger", lastReactionPosition, lastReactionPosition, "reaction", cancellationToken);
-                await projectionStore.SaveProjectionAsync($"{name}:projection", projectionPosition, projectionView, "reaction", cancellationToken);
+                await _reactionRepository.SaveCheckpointAsync(
+                    new ReactionCheckpoint(reaction.Name, lastReactionPosition, projectionPosition),
+                    cancellationToken);
             }
         }
 
-        // Save final projection state even if no triggers were processed
-        // (the projection may have advanced without new triggers)
-        if (projectionPosition > (projectionCheckpoint?.GlobalPosition ?? 0))
-        {
-            await projectionStore.SaveProjectionAsync($"{name}:projection", projectionPosition, projectionView, "reaction", cancellationToken);
-        }
+        await _reactionRepository.SaveCheckpointAsync(
+            new ReactionCheckpoint(reaction.Name, lastReactionPosition, projectionPosition),
+            cancellationToken);
 
         return lastReactionPosition;
     }
 
-    /// <summary>
-    /// Merges two event streams, yielding events in global position order.
-    /// When the same event appears in both streams (same global position), it's yielded once with both flags set.
-    /// </summary>
-    private static async IAsyncEnumerable<(StreamEvent Event, bool IsProjectionEvent, bool IsTriggerEvent)> MergeEventStreamsByPosition(
-        IAsyncEnumerable<StreamEvent> projectionStream,
-        IAsyncEnumerable<StreamEvent> triggerStream,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    private ReactionCheckpoint CreateInitialState(string reactionName)
     {
-        await using var projectionEnumerator = projectionStream.GetAsyncEnumerator(cancellationToken);
-        await using var triggerEnumerator = triggerStream.GetAsyncEnumerator(cancellationToken);
+        return new ReactionCheckpoint(
+                ReactionName: reactionName,
+                TriggerPosition: 0,
+                ProjectionPosition: 0);
+    }
 
-        bool hasProjection = await projectionEnumerator.MoveNextAsync();
-        bool hasTrigger = await triggerEnumerator.MoveNextAsync();
-
-        while (hasProjection || hasTrigger)
+    private void AddCorrelationIdMetadata(StreamEvent streamEvent, List<AppendMetadata> reactionMetadata)
+    {
+        var triggerCorrelationId = streamEvent.Metadata.GetCorrelationId();
+        if (triggerCorrelationId != null)
         {
-            if (hasProjection && hasTrigger)
+            reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.CorrelationId, triggerCorrelationId));
+        }
+        else
+        {
+            if (_logger?.IsEnabled(LogLevel.Critical) == true)
             {
-                var projPos = projectionEnumerator.Current.GlobalPosition;
-                var trigPos = triggerEnumerator.Current.GlobalPosition;
+                _logger.LogCritical("Trigger event at position {Position} in stream {Stream} is missing CorrelationId. " +
+                                    "This indicates a broken event metadata system. All events should have CorrelationId.",
+                                    streamEvent.GlobalPosition, streamEvent.StreamPointer.Stream);
+            }
+        }
+    }
 
-                if (projPos == trigPos)
-                {
-                    // Same event in both streams - yield once with both flags
-                    yield return (projectionEnumerator.Current, IsProjectionEvent: true, IsTriggerEvent: true);
-                    hasProjection = await projectionEnumerator.MoveNextAsync();
-                    hasTrigger = await triggerEnumerator.MoveNextAsync();
-                }
-                else if (projPos < trigPos)
-                {
-                    // Projection event comes first
-                    yield return (projectionEnumerator.Current, IsProjectionEvent: true, IsTriggerEvent: false);
-                    hasProjection = await projectionEnumerator.MoveNextAsync();
-                }
-                else
-                {
-                    // Trigger event comes first
-                    yield return (triggerEnumerator.Current, IsProjectionEvent: false, IsTriggerEvent: true);
-                    hasTrigger = await triggerEnumerator.MoveNextAsync();
-                }
-            }
-            else if (hasProjection)
+    private void AddEventIdMetadata(StreamEvent streamEvent, List<AppendMetadata> reactionMetadata)
+    {
+        var triggerEventId = streamEvent.Metadata.GetSystemEventId();
+        if (triggerEventId.HasValue)
+        {
+            reactionMetadata.Add(new AppendMetadata(EventMetadataKeys.CausationId, triggerEventId.Value));
+        }
+        else
+        {
+            if (_logger?.IsEnabled(LogLevel.Critical) == true)
             {
-                // Only projection events remaining
-                yield return (projectionEnumerator.Current, IsProjectionEvent: true, IsTriggerEvent: false);
-                hasProjection = await projectionEnumerator.MoveNextAsync();
-            }
-            else if (hasTrigger)
-            {
-                // Only trigger events remaining
-                yield return (triggerEnumerator.Current, IsProjectionEvent: false, IsTriggerEvent: true);
-                hasTrigger = await triggerEnumerator.MoveNextAsync();
+                _logger.LogCritical("Trigger event at position {Position} in stream {Stream} is missing system EventId. " +
+                                    "This indicates a broken event metadata system. All events should have system EventId.",
+                                    streamEvent.GlobalPosition, streamEvent.StreamPointer.Stream);
             }
         }
     }

--- a/Rickten.Reactor/ServiceCollectionExtensions.cs
+++ b/Rickten.Reactor/ServiceCollectionExtensions.cs
@@ -59,6 +59,9 @@ public static class ServiceCollectionExtensions
                 nameof(assemblies));
         }
 
+        // Register ReactionRunner as a singleton
+        services.TryAddSingleton<ReactionRunner>();
+
         foreach (var reactionType in FindReactionTypes(assemblies))
         {
             var reactionBaseType = FindReactionBaseType(reactionType)

--- a/Rickten.Reactor/ServiceCollectionExtensions.cs
+++ b/Rickten.Reactor/ServiceCollectionExtensions.cs
@@ -59,8 +59,8 @@ public static class ServiceCollectionExtensions
                 nameof(assemblies));
         }
 
-        // Register ReactionRunner as a singleton
-        services.TryAddSingleton<ReactionRunner>();
+        // Register ReactionRunner as scoped to match the lifetime of its EF-backed dependencies
+        services.TryAddScoped<ReactionRunner>();
 
         foreach (var reactionType in FindReactionTypes(assemblies))
         {

--- a/Rickten.Runtime.Tests/ReactionHostedServiceTests.cs
+++ b/Rickten.Runtime.Tests/ReactionHostedServiceTests.cs
@@ -73,7 +73,7 @@ public class TestProjection : Rickten.Projector.Projection<TestProjectionView>
 }
 
 // Test reaction with polling interval in attribute
-[Reaction("TestReaction", EventTypes = new[] { "TestAggregate.Triggered.v1" }, PollingIntervalMilliseconds = 100)]
+[Reaction("TestReaction", ["TestAggregate.Triggered.v1"], PollingIntervalMilliseconds = 100)]
 public class TestReaction : Reaction<TestProjectionView, ProcessTestCommand>
 {
     private readonly TestProjection _projection;
@@ -101,7 +101,7 @@ public class TestReaction : Reaction<TestProjectionView, ProcessTestCommand>
 }
 
 // Test reaction without polling interval (uses default)
-[Reaction("DefaultIntervalReaction", EventTypes = new[] { "TestAggregate.Triggered.v1" })]
+[Reaction("DefaultIntervalReaction", ["TestAggregate.Triggered.v1"])]
 public class DefaultIntervalReaction : Reaction<TestProjectionView, ProcessTestCommand>
 {
     private readonly TestProjection _projection;

--- a/Rickten.Runtime.Tests/ReactionHostedServiceTests.cs
+++ b/Rickten.Runtime.Tests/ReactionHostedServiceTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Rickten.Aggregator;
 using Rickten.EventStore;
+using Rickten.EventStore.EntityFramework;
 using Rickten.Projector;
 using Rickten.Reactor;
 using Rickten.TestUtils;
@@ -277,10 +279,16 @@ public class ReactionHostedServiceTests : IDisposable
         var services = new ServiceCollection();
 
         services.AddLogging();
-        services.AddSingleton(_connection);
+
+        // Register EventStore infrastructure (including IReactionRepository)
+        services.AddEventStore(options =>
+        {
+            options.UseSqlite(_connection);
+        }, typeof(TestReaction).Assembly);
+
+        // Override with shared instances from test fixture
         services.AddSingleton<IEventStore>(eventStore);
         services.AddSingleton<IProjectionStore>(_projectionStore);
-        services.AddSingleton(_serviceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>());
 
         services.AddReactions(typeof(TestReaction).Assembly);
 

--- a/Rickten.Runtime/ReactionHostedService.cs
+++ b/Rickten.Runtime/ReactionHostedService.cs
@@ -16,30 +16,26 @@ namespace Rickten.Runtime;
 /// <typeparam name="TState">The aggregate state type.</typeparam>
 /// <typeparam name="TView">The projection view type.</typeparam>
 /// <typeparam name="TCommand">The command type.</typeparam>
-internal class ReactionHostedService<TReaction, TState, TView, TCommand> : BackgroundService
+internal class ReactionHostedService<TReaction, TState, TView, TCommand>(
+    IServiceScopeFactory scopeFactory,
+    IOptions<RicktenRuntimeOptions> options,
+    ILogger<ReactionHostedService<TReaction, TState, TView, TCommand>> logger,
+    TimeSpan? pollingInterval = null) : BackgroundService
     where TReaction : Reaction<TView, TCommand>
 {
-    private readonly IServiceScopeFactory _scopeFactory;
-    private readonly ILogger<ReactionHostedService<TReaction, TState, TView, TCommand>> _logger;
-    private readonly TimeSpan _pollingInterval;
-
-    public ReactionHostedService(
-        IServiceScopeFactory scopeFactory,
-        IOptions<RicktenRuntimeOptions> options,
-        ILogger<ReactionHostedService<TReaction, TState, TView, TCommand>> logger,
-        TimeSpan? pollingInterval = null)
-    {
-        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _pollingInterval = pollingInterval ?? options.Value.DefaultPollingInterval;
-    }
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+    private readonly ILogger<ReactionHostedService<TReaction, TState, TView, TCommand>> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly TimeSpan _pollingInterval = pollingInterval ?? options.Value.DefaultPollingInterval;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var reactionName = typeof(TReaction).Name;
-        _logger.LogInformation(
-            "Starting hosted reaction '{ReactionName}' with polling interval {PollingInterval}",
-            reactionName, _pollingInterval);
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Starting hosted reaction '{ReactionName}' with polling interval {PollingInterval}",
+                reactionName, _pollingInterval);
+        }
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -47,36 +43,41 @@ internal class ReactionHostedService<TReaction, TState, TView, TCommand> : Backg
             {
                 await using var scope = _scopeFactory.CreateAsyncScope();
 
-                var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
-                var projectionStore = scope.ServiceProvider.GetRequiredService<IProjectionStore>();
+                var runner = scope.ServiceProvider.GetRequiredService<ReactionRunner>();
                 var reaction = scope.ServiceProvider.GetRequiredService<TReaction>();
                 var executor = scope.ServiceProvider.GetRequiredService<AggregateCommandExecutor<TState, TCommand>>();
 
-                var position = await ReactionRunner.CatchUpAsync(
-                    eventStore,
-                    projectionStore,
+                var position = await runner.CatchUpAsync(
                     reaction,
                     executor,
-                    logger: _logger,
-                    cancellationToken: stoppingToken);
+                    stoppingToken);
 
-                _logger.LogDebug(
-                    "Hosted reaction '{ReactionName}' caught up to position {Position}",
-                    reactionName, position);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Hosted reaction '{ReactionName}' caught up to position {Position}",
+                        reactionName, position);
+                }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation(
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation(
                     "Hosted reaction '{ReactionName}' stopping due to cancellation",
                     reactionName);
+                }
                 break;
             }
             catch (Exception ex)
             {
-                _logger.LogError(
-                    ex,
-                    "Hosted reaction '{ReactionName}' failed during catch-up. Will retry after {PollingInterval}",
-                    reactionName, _pollingInterval);
+                if (_logger.IsEnabled(LogLevel.Error))
+                {
+                    _logger.LogError(
+                        ex,
+                        "Hosted reaction '{ReactionName}' failed during catch-up. Will retry after {PollingInterval}",
+                        reactionName, _pollingInterval);
+                }
             }
 
             try
@@ -85,15 +86,21 @@ internal class ReactionHostedService<TReaction, TState, TView, TCommand> : Backg
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
-                _logger.LogInformation(
-                    "Hosted reaction '{ReactionName}' stopping during delay",
-                    reactionName);
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation(
+                        "Hosted reaction '{ReactionName}' stopping during delay",
+                        reactionName);
+                }
                 break;
             }
         }
 
-        _logger.LogInformation(
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
             "Hosted reaction '{ReactionName}' stopped",
             reactionName);
+        }
     }
 }


### PR DESCRIPTION
#### PR Classification
Design and architectural refactor to improve reaction checkpointing, event processing, and dependency injection support.

#### PR Summary
This PR separates reaction execution checkpoints from projection view state, introduces a DI-based ReactionRunner service, and enforces explicit event type filtering for reactions. It enhances recovery, drift detection, and at-least-once guarantees, with updated documentation and tests.
- ReactionRunner.cs: Refactored to an instance-based DI service, now manages checkpointing and projection drift using IReactionRepository and IProjectionStore.
- ReactionAttribute.cs and Reaction<TView, TCommand>: Attribute now requires explicit event types; reaction metadata and filtering logic updated.
- IEventStore.cs and EventStore.cs: Added LoadAllMergedAsync for efficient event merging and filtering.
- ServiceCollectionExtensions.cs: Registers ReactionRunner and IReactionRepository for DI.
- Updated tests and README.md to reflect new checkpointing model, idempotency requirements, and DI usage.

Fixes #37