### PR TITLE
Convert ProjectionRunner to instance-based service with DI support

### DIFF
--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -47,10 +47,16 @@ public sealed class EventStore(
         long fromGlobalPosition = 0,
         string[]? streamTypeFilter = null,
         string[]? eventsFilter = null,
+        long? untilGlobalPosition = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var query = _context.Events
             .Where(e => e.Id > fromGlobalPosition);
+
+        if (untilGlobalPosition.HasValue)
+        {
+            query = query.Where(e => e.Id <= untilGlobalPosition.Value);
+        }
 
         if (streamTypeFilter?.Length > 0)
         {
@@ -85,7 +91,7 @@ public sealed class EventStore(
 
         // Load streams for each filter
         var streams = filters.Select((filter, index) =>
-            LoadAllAsync(fromGlobalPosition, filter.streamTypeFilter, filter.eventsFilter, cancellationToken)
+            LoadAllAsync(fromGlobalPosition, filter.streamTypeFilter, filter.eventsFilter, untilGlobalPosition: null, cancellationToken)
         ).ToArray();
 
         // Use the extension method to merge, but we need to track which filter each stream came from

--- a/Rickten.EventStore/IEventStore.cs
+++ b/Rickten.EventStore/IEventStore.cs
@@ -25,12 +25,14 @@ public interface IEventStore
     /// <param name="fromGlobalPosition">The global position to start loading after (exclusive). Defaults to 0 (beginning).</param>
     /// <param name="streamTypeFilter">Optional filter to include only specific stream types.</param>
     /// <param name="eventsFilter">Optional filter to include only specific event types.</param>
+    /// <param name="untilGlobalPosition">Optional upper bound (inclusive). Only events with global position &lt;= this value are returned. Null means no upper limit.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>An async enumerable of stream events from all matching streams.</returns>
     IAsyncEnumerable<StreamEvent> LoadAllAsync(
         long fromGlobalPosition = 0,
         string[]? streamTypeFilter = null,
         string[]? eventsFilter = null,
+        long? untilGlobalPosition = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/Rickten.Projector.Tests/ProjectionRunnerTests.cs
+++ b/Rickten.Projector.Tests/ProjectionRunnerTests.cs
@@ -126,9 +126,7 @@ public class ProjectionRunnerTests : IDisposable
         ]);
 
         // First catch-up: process all events
-        var (firstView, firstCheckpoint) = await runner.CatchUpAsync(
-            projection,
-            "OrderCounter");
+        var (firstView, firstCheckpoint) = await runner.CatchUpAsync(projection);
 
         Assert.Equal(3, firstView.Count); // 3 events processed
         Assert.True(firstCheckpoint > 0);
@@ -147,9 +145,7 @@ public class ProjectionRunnerTests : IDisposable
         ]);
 
         // Second catch-up: should resume from checkpoint and process only new events
-        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(
-            projection,
-            "OrderCounter");
+        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(projection);
 
         // Critical assertion: should be 5 total (3 from before + 2 new)
         // If it replayed the checkpoint event, it would be 6
@@ -191,9 +187,7 @@ public class ProjectionRunnerTests : IDisposable
         Assert.True(firstCheckpoint > 0);
 
         // Second catch-up with no new events
-        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(
-            projection,
-            "NoUpdateTest");
+        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(projection);
 
         // Should return same view and checkpoint
         Assert.Equal(1, secondView.Count);
@@ -302,9 +296,7 @@ public class ProjectionRunnerTests : IDisposable
         ]);
 
         // First catch-up
-        var (firstView, _) = await runner.CatchUpAsync(
-            projection,
-            "EventTypeFilteredTest");
+        var (firstView, _) = await runner.CatchUpAsync(projection);
 
         Assert.Equal(1, firstView.Count); // Only Created event
 

--- a/Rickten.Projector.Tests/ProjectionRunnerTests.cs
+++ b/Rickten.Projector.Tests/ProjectionRunnerTests.cs
@@ -22,7 +22,7 @@ public class OrderCounterState
 [Projection("OrderCounter", AggregateTypes = new[] { "TestOrder" })]
 public class OrderCounterProjection : Projection<OrderCounterState>
 {
-    public override OrderCounterState InitialView() => new OrderCounterState { Count = 0 };
+    public override OrderCounterState InitialView() => new() { Count = 0 };
     protected override OrderCounterState ApplyEvent(OrderCounterState view, StreamEvent streamEvent)
     {
         return new OrderCounterState { Count = view.Count + 1 };
@@ -43,6 +43,7 @@ public class ProjectionRunnerTests : IDisposable
     {
         _connection?.Dispose();
         (_serviceProvider as IDisposable)?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     [Fact]
@@ -53,26 +54,26 @@ public class ProjectionRunnerTests : IDisposable
         // not >= N, to avoid double-processing the checkpoint event.
 
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new OrderCounterProjection();
 
         // Create initial events
         var stream1 = new StreamIdentifier("TestOrder", "rebuild-1");
         var stream2 = new StreamIdentifier("TestOrder", "rebuild-2");
 
-        await eventStore.AppendAsync(new StreamPointer(stream1, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream1, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null)
+        ]);
 
-        await eventStore.AppendAsync(new StreamPointer(stream2, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-2", 200m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream2, 0),
+        [
+            new(new TestOrderCreatedEvent("order-2", 200m), null)
+        ]);
 
         // Simulate first rebuild: process all events and save checkpoint
-        var (firstView, firstCheckpoint) = await ProjectionRunner.RebuildAsync(
-            eventStore,
+        var (firstView, firstCheckpoint) = await runner.RebuildAsync(
             projection,
             fromGlobalPosition: 0);
 
@@ -80,22 +81,21 @@ public class ProjectionRunnerTests : IDisposable
         Assert.True(firstCheckpoint > 0);
 
         // Add more events after checkpoint
-        await eventStore.AppendAsync(new StreamPointer(stream1, 2), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Confirmed"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream1, 2),
+        [
+            new(new TestOrderUpdatedEvent("order-1", "Confirmed"), null)
+        ]);
 
-        await eventStore.AppendAsync(new StreamPointer(stream2, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderUpdatedEvent("order-2", "Shipped"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream2, 1),
+        [
+            new(new TestOrderUpdatedEvent("order-2", "Shipped"), null)
+        ]);
 
         // Rebuild from checkpoint - should ONLY process new events (2 events)
         // NOT the checkpoint event itself
-        var (secondView, secondCheckpoint) = await ProjectionRunner.RebuildAsync(
-            eventStore,
+        var (secondView, secondCheckpoint) = await runner.RebuildAsync(
             projection,
-            fromGlobalPosition: firstCheckpoint);
+            firstCheckpoint);
 
         // Critical assertion: should count only 2 new events, not 3
         // If it counted 3, it would have replayed the checkpoint event
@@ -112,22 +112,21 @@ public class ProjectionRunnerTests : IDisposable
 
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
         var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new OrderCounterProjection();
 
         var stream = new StreamIdentifier("TestOrder", "catchup-1");
 
         // Create initial events
-        await eventStore.AppendAsync(new StreamPointer(stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Confirmed"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null),
+            new(new TestOrderUpdatedEvent("order-1", "Confirmed"), null)
+        ]);
 
         // First catch-up: process all events
-        var (firstView, firstCheckpoint) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (firstView, firstCheckpoint) = await runner.CatchUpAsync(
             projection,
             "OrderCounter");
 
@@ -141,16 +140,14 @@ public class ProjectionRunnerTests : IDisposable
         Assert.Equal(firstCheckpoint, savedCheckpoint.GlobalPosition);
 
         // Add more events
-        await eventStore.AppendAsync(new StreamPointer(stream, 3), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Shipped"), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Delivered"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 3),
+        [
+            new(new TestOrderUpdatedEvent("order-1", "Shipped"), null),
+            new(new TestOrderUpdatedEvent("order-1", "Delivered"), null)
+        ]);
 
         // Second catch-up: should resume from checkpoint and process only new events
-        var (secondView, secondCheckpoint) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(
             projection,
             "OrderCounter");
 
@@ -174,20 +171,19 @@ public class ProjectionRunnerTests : IDisposable
 
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
         var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new OrderCounterProjection();
 
         var stream = new StreamIdentifier("TestOrder", "no-update-1");
 
         // Create events
-        await eventStore.AppendAsync(new StreamPointer(stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null)
+        ]);
 
         // First catch-up
-        var (firstView, firstCheckpoint) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (firstView, firstCheckpoint) = await runner.CatchUpAsync(
             projection,
             "NoUpdateTest");
 
@@ -195,9 +191,7 @@ public class ProjectionRunnerTests : IDisposable
         Assert.True(firstCheckpoint > 0);
 
         // Second catch-up with no new events
-        var (secondView, secondCheckpoint) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(
             projection,
             "NoUpdateTest");
 
@@ -210,27 +204,27 @@ public class ProjectionRunnerTests : IDisposable
     public async Task RebuildAsync_WithFilters_ProcessesOnlyMatchingEvents()
     {
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new OrderCounterProjection(); // Filtered to TestOrder aggregate
 
         // Create events for TestOrder
         var orderStream = new StreamIdentifier("TestOrder", "filtered-1");
-        await eventStore.AppendAsync(new StreamPointer(orderStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(orderStream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null)
+        ]);
 
         // Create events for a different aggregate type (should be filtered out)
         var otherStream = new StreamIdentifier("OtherAggregate", "filtered-2");
-        await eventStore.AppendAsync(new StreamPointer(otherStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new OtherAggregateCreatedEvent("other-1", "some data"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(otherStream, 0),
+        [
+            new(new OtherAggregateCreatedEvent("other-1", "some data"), null)
+        ]);
 
-        var (view, _) = await ProjectionRunner.RebuildAsync(
-            eventStore,
+        var (view, _) = await runner.RebuildAsync(
             projection,
-            fromGlobalPosition: 0);
+            0);
 
         // Should count only the 2 TestOrder events, not the OtherAggregate event
         Assert.Equal(2, view.Count);
@@ -240,20 +234,20 @@ public class ProjectionRunnerTests : IDisposable
     public async Task RebuildAsync_WithEventTypeFilter_ProcessesOnlyMatchingEvents()
     {
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new EventTypeFilteredProjection(); // Filtered to TestOrder.Created.v1
 
         var orderStream = new StreamIdentifier("TestOrder", "event-filtered-1");
-        await eventStore.AppendAsync(new StreamPointer(orderStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null),
-            new AppendEvent(new TestOrderCreatedEvent("order-2", 200m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(orderStream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null),
+            new(new TestOrderCreatedEvent("order-2", 200m), null)
+        ]);
 
-        var (view, _) = await ProjectionRunner.RebuildAsync(
-            eventStore,
+        var (view, _) = await runner.RebuildAsync(
             projection,
-            fromGlobalPosition: 0);
+            0);
 
         // Should count only the 2 Created events, not the Updated event
         Assert.Equal(2, view.Count);
@@ -263,28 +257,28 @@ public class ProjectionRunnerTests : IDisposable
     public async Task RebuildAsync_WithBothFilters_ProcessesOnlyMatchingEvents()
     {
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new BothFiltersProjection(); // Filtered to TestOrder aggregate AND Created events
 
         // TestOrder events - only Created should be processed
         var orderStream = new StreamIdentifier("TestOrder", "both-filtered-1");
-        await eventStore.AppendAsync(new StreamPointer(orderStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null),
-            new AppendEvent(new TestOrderCreatedEvent("order-2", 200m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(orderStream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null),
+            new(new TestOrderCreatedEvent("order-2", 200m), null)
+        ]);
 
         // OtherAggregate events - should be filtered out by aggregate type
         var otherStream = new StreamIdentifier("OtherAggregate", "both-filtered-2");
-        await eventStore.AppendAsync(new StreamPointer(otherStream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new OtherAggregateCreatedEvent("other-1", "data"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(otherStream, 0),
+        [
+            new(new OtherAggregateCreatedEvent("other-1", "data"), null)
+        ]);
 
-        var (view, _) = await ProjectionRunner.RebuildAsync(
-            eventStore,
+        var (view, _) = await runner.RebuildAsync(
             projection,
-            fromGlobalPosition: 0);
+            0);
 
         // Should count only the 2 TestOrder.Created events
         Assert.Equal(2, view.Count);
@@ -295,38 +289,35 @@ public class ProjectionRunnerTests : IDisposable
     {
         var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
         var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
         var projection = new EventTypeFilteredProjection();
 
         var stream = new StreamIdentifier("TestOrder", "catchup-event-filtered");
 
         // Initial events
-        await eventStore.AppendAsync(new StreamPointer(stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null)
+        ]);
 
         // First catch-up
-        var (firstView, _) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (firstView, _) = await runner.CatchUpAsync(
             projection,
             "EventTypeFilteredTest");
 
         Assert.Equal(1, firstView.Count); // Only Created event
 
         // Add more events
-        await eventStore.AppendAsync(new StreamPointer(stream, 2), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-2", 200m), null),
-            new AppendEvent(new TestOrderUpdatedEvent("order-2", "Confirmed"), null),
-            new AppendEvent(new TestOrderCreatedEvent("order-3", 300m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 2),
+        [
+            new(new TestOrderCreatedEvent("order-2", 200m), null),
+            new(new TestOrderUpdatedEvent("order-2", "Confirmed"), null),
+            new(new TestOrderCreatedEvent("order-3", 300m), null)
+        ]);
 
         // Second catch-up
-        var (secondView, _) = await ProjectionRunner.CatchUpAsync(
-            eventStore,
-            projectionStore,
+        var (secondView, _) = await runner.CatchUpAsync(
             projection,
             "EventTypeFilteredTest");
 
@@ -344,10 +335,10 @@ public class ProjectionRunnerTests : IDisposable
         var projection = new EventTypeFilteredProjection(); // Filtered to TestOrder.Created.v1
 
         var stream = new StreamIdentifier("TestOrder", "mismatch-test");
-        await eventStore.AppendAsync(new StreamPointer(stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderCreatedEvent("order-1", 100m), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null)
+        ]);
 
         // Now load ALL events without filtering (simulating misconfiguration)
         var allEvents = new List<StreamEvent>();
@@ -365,10 +356,10 @@ public class ProjectionRunnerTests : IDisposable
         Assert.Equal(1, view.Count);
 
         // Now add an Updated event that won't be filtered by the query
-        await eventStore.AppendAsync(new StreamPointer(stream, 1), new List<AppendEvent>
-        {
-            new AppendEvent(new TestOrderUpdatedEvent("order-1", "Pending"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 1),
+        [
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null)
+        ]);
 
         // Load without event type filter (misconfiguration)
         var newEvents = new List<StreamEvent>();
@@ -394,10 +385,10 @@ public class ProjectionRunnerTests : IDisposable
         var projection = new OrderCounterProjection(); // Filtered to TestOrder
 
         var stream = new StreamIdentifier("OtherAggregate", "aggregate-mismatch");
-        await eventStore.AppendAsync(new StreamPointer(stream, 0), new List<AppendEvent>
-        {
-            new AppendEvent(new OtherAggregateCreatedEvent("other-1", "data"), null)
-        });
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new OtherAggregateCreatedEvent("other-1", "data"), null)
+        ]);
 
         // Load without aggregate filter (misconfiguration)
         var events = new List<StreamEvent>();
@@ -420,7 +411,7 @@ public class ProjectionRunnerTests : IDisposable
 [Projection("EventTypeFiltered", EventTypes = new[] { "TestOrder.Created.v1" })]
 public class EventTypeFilteredProjection : Projection<OrderCounterState>
 {
-    public override OrderCounterState InitialView() => new OrderCounterState { Count = 0 };
+    public override OrderCounterState InitialView() => new() { Count = 0 };
     protected override OrderCounterState ApplyEvent(OrderCounterState view, StreamEvent streamEvent)
     {
         return new OrderCounterState { Count = view.Count + 1 };
@@ -430,7 +421,7 @@ public class EventTypeFilteredProjection : Projection<OrderCounterState>
 [Projection("BothFilters", AggregateTypes = new[] { "TestOrder" }, EventTypes = new[] { "TestOrder.Created.v1" })]
 public class BothFiltersProjection : Projection<OrderCounterState>
 {
-    public override OrderCounterState InitialView() => new OrderCounterState { Count = 0 };
+    public override OrderCounterState InitialView() => new() { Count = 0 };
     protected override OrderCounterState ApplyEvent(OrderCounterState view, StreamEvent streamEvent)
     {
         return new OrderCounterState { Count = view.Count + 1 };

--- a/Rickten.Projector.Tests/ProjectionRunnerTests.cs
+++ b/Rickten.Projector.Tests/ProjectionRunnerTests.cs
@@ -400,6 +400,79 @@ public class ProjectionRunnerTests : IDisposable
         Assert.Contains("TestOrder", ex.Message);
         Assert.Contains("filter", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task CatchUpAsync_DifferentNamespaces_MaintainSeparateCheckpoints()
+    {
+        // Verifies that the same projection type in different namespaces
+        // maintains completely separate checkpoint state
+        var eventStore = _serviceProvider.GetRequiredService<IEventStore>();
+        var projectionStore = _serviceProvider.GetRequiredService<IProjectionStore>();
+        var runner = _serviceProvider.GetRequiredService<ProjectionRunner>();
+        var projection = new OrderCounterProjection();
+
+        var stream = new StreamIdentifier("TestOrder", "namespace-test");
+
+        // Create initial events
+        await eventStore.AppendAsync(new StreamPointer(stream, 0),
+        [
+            new(new TestOrderCreatedEvent("order-1", 100m), null),
+            new(new TestOrderUpdatedEvent("order-1", "Pending"), null)
+        ]);
+
+        // Catch up in "system" namespace
+        var (systemView1, systemCheckpoint1) = await runner.CatchUpAsync(
+            projection,
+            "system");
+
+        Assert.Equal(2, systemView1.Count);
+        Assert.True(systemCheckpoint1 > 0);
+
+        // Catch up in "testing" namespace - should start from zero, not from system checkpoint
+        var (testingView1, testingCheckpoint1) = await runner.CatchUpAsync(
+            projection,
+            "testing");
+
+        Assert.Equal(2, testingView1.Count); // Processes all events, not from system checkpoint
+        Assert.Equal(systemCheckpoint1, testingCheckpoint1); // Same final position
+
+        // Add more events
+        await eventStore.AppendAsync(new StreamPointer(stream, 2),
+        [
+            new(new TestOrderCreatedEvent("order-2", 200m), null)
+        ]);
+
+        // Catch up system namespace - should process 1 new event
+        var (systemView2, systemCheckpoint2) = await runner.CatchUpAsync(
+            projection,
+            "system");
+
+        Assert.Equal(3, systemView2.Count); // 2 previous + 1 new
+        Assert.True(systemCheckpoint2 > systemCheckpoint1);
+
+        // Catch up testing namespace - should also process 1 new event
+        var (testingView2, testingCheckpoint2) = await runner.CatchUpAsync(
+            projection,
+            "testing");
+
+        Assert.Equal(3, testingView2.Count); // 2 previous + 1 new
+        Assert.Equal(systemCheckpoint2, testingCheckpoint2); // Same final position
+
+        // Verify both namespaces have separate stored checkpoints
+        var systemStored = await projectionStore.LoadProjectionAsync<OrderCounterState>(
+            "OrderCounter",
+            "system");
+        var testingStored = await projectionStore.LoadProjectionAsync<OrderCounterState>(
+            "OrderCounter",
+            "testing");
+
+        Assert.NotNull(systemStored);
+        Assert.NotNull(testingStored);
+        Assert.Equal(3, systemStored.State.Count);
+        Assert.Equal(3, testingStored.State.Count);
+        Assert.Equal(systemCheckpoint2, systemStored.GlobalPosition);
+        Assert.Equal(testingCheckpoint2, testingStored.GlobalPosition);
+    }
 }
 
 [Projection("EventTypeFiltered", EventTypes = new[] { "TestOrder.Created.v1" })]

--- a/Rickten.Projector.Tests/ProjectionRunnerTests.cs
+++ b/Rickten.Projector.Tests/ProjectionRunnerTests.cs
@@ -186,8 +186,10 @@ public class ProjectionRunnerTests : IDisposable
         Assert.Equal(1, firstView.Count);
         Assert.True(firstCheckpoint > 0);
 
-        // Second catch-up with no new events
-        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(projection);
+        // Second catch-up with no new events (same namespace)
+        var (secondView, secondCheckpoint) = await runner.CatchUpAsync(
+            projection,
+            "NoUpdateTest");
 
         // Should return same view and checkpoint
         Assert.Equal(1, secondView.Count);

--- a/Rickten.Projector.Tests/TestDbContextFactory.cs
+++ b/Rickten.Projector.Tests/TestDbContextFactory.cs
@@ -32,6 +32,9 @@ public static class TestServiceFactory
             options.UseSqlite(connection);
         }, typeof(TestServiceFactory).Assembly);
 
+        // Register ProjectionRunner
+        services.AddProjectionRunner();
+
         var serviceProvider = services.BuildServiceProvider();
 
         // Create the database schema

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -208,12 +208,23 @@ public sealed class ProjectionRunner(IEventStore eventStore,
 
         if (currentPosition < targetPosition)
         {
-            // Projection behind - catch up from checkpoint
-            return await CatchUpUntilAsync(
-                projection,
+            // Projection behind - advance from current state without reloading
+            // (caller manages their own checkpoint key)
+            var view = currentView;
+            var lastGlobalPosition = currentPosition;
+
+            await foreach (var streamEvent in _eventStore.LoadAllAsync(
+                currentPosition,
+                projection.AggregateTypeFilter,
+                projection.EventTypeFilter,
                 targetPosition,
-                @namespace,
-                cancellationToken);
+                cancellationToken))
+            {
+                view = projection.Apply(view, streamEvent);
+                lastGlobalPosition = streamEvent.GlobalPosition;
+            }
+
+            return (view, lastGlobalPosition);
         }
 
         // Equal - no action needed

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -87,53 +87,28 @@ public sealed class ProjectionRunner(IEventStore eventStore,
     }
 
     /// <summary>
-    /// Catches up a projection from its last checkpoint in the "system" namespace.
+    /// Catches up a projection from its last checkpoint.
     /// Loads the checkpoint from the projection store, applies new events, and saves the updated view.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
     /// <param name="projection">The projection to apply.</param>
-    /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
+    /// <param name="namespace">The namespace for the projection (defaults to "system").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The current view and checkpoint global position.</returns>
     public async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
         IProjection<TView> projection,
-        string? projectionName = null,
+        string @namespace = "system",
         CancellationToken cancellationToken = default)
     {
-        return await CatchUpAsync(projection, projectionName, "system", cancellationToken);
-    }
-
-    /// <summary>
-    /// Catches up a projection from its last checkpoint in a specific namespace.
-    /// Loads the checkpoint from the projection store, applies new events, and saves the updated view.
-    /// </summary>
-    /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="projection">The projection to apply.</param>
-    /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
-    /// <param name="namespace">The namespace for the projection.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The current view and checkpoint global position.</returns>
-    public async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
-        IProjection<TView> projection,
-        string? projectionName,
-        string @namespace,
-        CancellationToken cancellationToken = default)
-    {
-        // Determine projection name
-        var name = projectionName;
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrEmpty(projection.ProjectionName))
         {
-            name = projection.ProjectionName;
-        }
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentException(
-                "Projection name must be provided either via parameter or [Projection] attribute",
-                nameof(projectionName));
+            throw new InvalidOperationException(
+                $"Projection '{projection.GetType().Name}' does not have a name. " +
+                "Apply [Projection(\"name\")] attribute to the projection class.");
         }
 
         // Load last checkpoint
-        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
+        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(projection.ProjectionName, @namespace, cancellationToken);
         var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
         var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
 
@@ -153,7 +128,7 @@ public sealed class ProjectionRunner(IEventStore eventStore,
         // Save updated checkpoint if we processed any events
         if (lastGlobalPosition > fromGlobalPosition)
         {
-            await _projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
+            await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
         }
 
         return (view, lastGlobalPosition);
@@ -166,32 +141,24 @@ public sealed class ProjectionRunner(IEventStore eventStore,
     /// <typeparam name="TView">The view type.</typeparam>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="untilGlobalPosition">Process events up to and including this global position.</param>
-    /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
     /// <param name="namespace">The namespace for the projection.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected view and the last processed global position.</returns>
     public async Task<(TView View, long GlobalPosition)> CatchUpUntilAsync<TView>(
         IProjection<TView> projection,
         long untilGlobalPosition,
-        string? projectionName = null,
         string @namespace = "system",
         CancellationToken cancellationToken = default)
     {
-        // Determine projection name
-        var name = projectionName;
-        if (string.IsNullOrEmpty(name))
+        if (string.IsNullOrEmpty(projection.ProjectionName))
         {
-            name = projection.ProjectionName;
-        }
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentException(
-                "Projection name must be provided either via parameter or [Projection] attribute",
-                nameof(projectionName));
+            throw new InvalidOperationException(
+                $"Projection '{projection.GetType().Name}' does not have a name. " +
+                "Apply [Projection(\"name\")] attribute to the projection class.");
         }
 
         // Load last checkpoint
-        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
+        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(projection.ProjectionName, @namespace, cancellationToken);
         var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
         var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
 
@@ -211,7 +178,7 @@ public sealed class ProjectionRunner(IEventStore eventStore,
         // Save updated checkpoint if we processed any events
         if (lastGlobalPosition > fromGlobalPosition)
         {
-            await _projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
+            await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
         }
 
         return (view, lastGlobalPosition);
@@ -228,7 +195,6 @@ public sealed class ProjectionRunner(IEventStore eventStore,
     /// <param name="currentView">The current projection view state.</param>
     /// <param name="currentPosition">The current projection position.</param>
     /// <param name="targetPosition">The target position to synchronize to.</param>
-    /// <param name="projectionName">The name to use for loading the projection (defaults to projection's name if available).</param>
     /// <param name="namespace">The namespace for the projection.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The synchronized view and position.</returns>
@@ -237,7 +203,6 @@ public sealed class ProjectionRunner(IEventStore eventStore,
         TView currentView,
         long currentPosition,
         long targetPosition,
-        string? projectionName = null,
         string @namespace = "system",
         CancellationToken cancellationToken = default)
     {
@@ -257,7 +222,6 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             return await CatchUpUntilAsync(
                 projection,
                 targetPosition,
-                projectionName,
                 @namespace,
                 cancellationToken);
         }

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -1,24 +1,34 @@
+using Microsoft.Extensions.Logging;
 using Rickten.EventStore;
 
 namespace Rickten.Projector;
 
 /// <summary>
-/// Utilities for projecting events into read model views.
+/// Executes projections for building event-sourced read model views.
 /// </summary>
-public static class ProjectionRunner
+/// <remarks>
+/// Initializes a new instance of the <see cref="ProjectionRunner"/> class.
+/// </remarks>
+/// <param name="eventStore">The event store to load events from.</param>
+/// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
+/// <param name="logger">Optional logger for diagnostic information.</param>
+public sealed class ProjectionRunner(IEventStore eventStore,
+                                      IProjectionStore projectionStore,
+                                      ILogger<ProjectionRunner>? logger = null)
 {
+    private readonly IProjectionStore _projectionStore  = projectionStore;
+    private readonly IEventStore _eventStore            = eventStore;
+    private readonly ILogger<ProjectionRunner>? _logger = logger;
     /// <summary>
     /// Rebuilds a projection from scratch starting at a specific global position.
     /// Does not save checkpoints - caller is responsible for persistence.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="fromGlobalPosition">The global position to start from (default: 0 = beginning).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected view and the last processed global position.</returns>
-    public static async Task<(TView View, long LastGlobalPosition)> RebuildAsync<TView>(
-        IEventStore eventStore,
+    public async Task<(TView View, long LastGlobalPosition)> RebuildAsync<TView>(
         IProjection<TView> projection,
         long fromGlobalPosition = 0,
         CancellationToken cancellationToken = default)
@@ -27,7 +37,7 @@ public static class ProjectionRunner
         long lastGlobalPosition = fromGlobalPosition;
 
         // Load events with optional filtering
-        await foreach (var streamEvent in eventStore.LoadAllAsync(
+        await foreach (var streamEvent in _eventStore.LoadAllAsync(
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
@@ -46,14 +56,12 @@ public static class ProjectionRunner
     /// Useful for reactions that need projection state at a specific historical point.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="untilGlobalPosition">Process events up to and including this global position.</param>
     /// <param name="fromGlobalPosition">The global position to start from (default: 0 = beginning).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected view and the last processed global position.</returns>
-    public static async Task<(TView View, long LastGlobalPosition)> RebuildUntilAsync<TView>(
-        IEventStore eventStore,
+    public async Task<(TView View, long LastGlobalPosition)> RebuildUntilAsync<TView>(
         IProjection<TView> projection,
         long untilGlobalPosition,
         long fromGlobalPosition = 0,
@@ -63,7 +71,7 @@ public static class ProjectionRunner
         long lastGlobalPosition = fromGlobalPosition;
 
         // Load events with optional filtering, stopping at untilGlobalPosition (inclusive)
-        await foreach (var streamEvent in eventStore.LoadAllAsync(
+        await foreach (var streamEvent in _eventStore.LoadAllAsync(
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
@@ -87,20 +95,16 @@ public static class ProjectionRunner
     /// Loads the checkpoint from the projection store, applies new events, and saves the updated view.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
-    /// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The current view and checkpoint global position.</returns>
-    public static async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
-        IEventStore eventStore,
-        IProjectionStore projectionStore,
+    public async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
         IProjection<TView> projection,
         string? projectionName = null,
         CancellationToken cancellationToken = default)
     {
-        return await CatchUpAsync(eventStore, projectionStore, projection, projectionName, "system", cancellationToken);
+        return await CatchUpAsync(projection, projectionName, "system", cancellationToken);
     }
 
     /// <summary>
@@ -108,16 +112,12 @@ public static class ProjectionRunner
     /// Loads the checkpoint from the projection store, applies new events, and saves the updated view.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
-    /// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
     /// <param name="namespace">The namespace for the projection.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The current view and checkpoint global position.</returns>
-    public static async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
-        IEventStore eventStore,
-        IProjectionStore projectionStore,
+    public async Task<(TView View, long GlobalPosition)> CatchUpAsync<TView>(
         IProjection<TView> projection,
         string? projectionName,
         string @namespace,
@@ -137,13 +137,13 @@ public static class ProjectionRunner
         }
 
         // Load last checkpoint
-        var checkpoint = await projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
+        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
         var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
         var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
 
         // Process new events
         var lastGlobalPosition = fromGlobalPosition;
-        await foreach (var streamEvent in eventStore.LoadAllAsync(
+        await foreach (var streamEvent in _eventStore.LoadAllAsync(
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
@@ -156,7 +156,7 @@ public static class ProjectionRunner
         // Save updated checkpoint if we processed any events
         if (lastGlobalPosition > fromGlobalPosition)
         {
-            await projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
+            await _projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
         }
 
         return (view, lastGlobalPosition);
@@ -167,17 +167,13 @@ public static class ProjectionRunner
     /// Loads the checkpoint from the projection store, applies events up to the target position, and saves if progress was made.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
-    /// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="untilGlobalPosition">Process events up to and including this global position.</param>
     /// <param name="projectionName">The name to use for storing the projection (defaults to projection's name if available).</param>
     /// <param name="namespace">The namespace for the projection.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected view and the last processed global position.</returns>
-    public static async Task<(TView View, long GlobalPosition)> CatchUpUntilAsync<TView>(
-        IEventStore eventStore,
-        IProjectionStore projectionStore,
+    public async Task<(TView View, long GlobalPosition)> CatchUpUntilAsync<TView>(
         IProjection<TView> projection,
         long untilGlobalPosition,
         string? projectionName = null,
@@ -198,13 +194,13 @@ public static class ProjectionRunner
         }
 
         // Load last checkpoint
-        var checkpoint = await projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
+        var checkpoint = await _projectionStore.LoadProjectionAsync<TView>(name, @namespace, cancellationToken);
         var view = checkpoint is not null ? checkpoint.State : projection.InitialView();
         var fromGlobalPosition = checkpoint?.GlobalPosition ?? 0;
 
         // Process events up to target position
         var lastGlobalPosition = fromGlobalPosition;
-        await foreach (var streamEvent in eventStore.LoadAllAsync(
+        await foreach (var streamEvent in _eventStore.LoadAllAsync(
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
@@ -223,7 +219,7 @@ public static class ProjectionRunner
         // Save updated checkpoint if we processed any events
         if (lastGlobalPosition > fromGlobalPosition)
         {
-            await projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
+            await _projectionStore.SaveProjectionAsync(name, lastGlobalPosition, view, @namespace, cancellationToken);
         }
 
         return (view, lastGlobalPosition);
@@ -236,8 +232,6 @@ public static class ProjectionRunner
     /// If equal, returns current view unchanged.
     /// </summary>
     /// <typeparam name="TView">The view type.</typeparam>
-    /// <param name="eventStore">The event store to load events from.</param>
-    /// <param name="projectionStore">The projection store for loading checkpoints.</param>
     /// <param name="projection">The projection to apply.</param>
     /// <param name="currentView">The current projection view state.</param>
     /// <param name="currentPosition">The current projection position.</param>
@@ -246,9 +240,7 @@ public static class ProjectionRunner
     /// <param name="namespace">The namespace for the projection.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The synchronized view and position.</returns>
-    public static async Task<(TView View, long Position)> SyncToPositionAsync<TView>(
-        IEventStore eventStore,
-        IProjectionStore projectionStore,
+    public async Task<(TView View, long Position)> SyncToPositionAsync<TView>(
         IProjection<TView> projection,
         TView currentView,
         long currentPosition,
@@ -261,7 +253,6 @@ public static class ProjectionRunner
         {
             // Projection ahead - must rebuild from scratch (can't go backwards)
             return await RebuildUntilAsync(
-                eventStore,
                 projection,
                 targetPosition,
                 fromGlobalPosition: 0,
@@ -272,8 +263,6 @@ public static class ProjectionRunner
         {
             // Projection behind - catch up from checkpoint
             return await CatchUpUntilAsync(
-                eventStore,
-                projectionStore,
                 projection,
                 targetPosition,
                 projectionName,

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -41,6 +41,7 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
+            untilGlobalPosition: null,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
@@ -70,21 +71,16 @@ public sealed class ProjectionRunner(IEventStore eventStore,
         var view = projection.InitialView();
         long lastGlobalPosition = fromGlobalPosition;
 
-        // Load events with optional filtering, stopping at untilGlobalPosition (inclusive)
+        // Load events with optional filtering up to untilGlobalPosition (inclusive)
         await foreach (var streamEvent in _eventStore.LoadAllAsync(
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
+            untilGlobalPosition,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
             lastGlobalPosition = streamEvent.GlobalPosition;
-
-            // Stop if we've reached the target position (inclusive)
-            if (streamEvent.GlobalPosition >= untilGlobalPosition)
-            {
-                break;
-            }
         }
 
         return (view, lastGlobalPosition);
@@ -147,6 +143,7 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
+            untilGlobalPosition: null,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
@@ -204,16 +201,11 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             fromGlobalPosition,
             projection.AggregateTypeFilter,
             projection.EventTypeFilter,
+            untilGlobalPosition,
             cancellationToken))
         {
             view = projection.Apply(view, streamEvent);
             lastGlobalPosition = streamEvent.GlobalPosition;
-
-            // Stop if we've reached the target position (inclusive)
-            if (streamEvent.GlobalPosition >= untilGlobalPosition)
-            {
-                break;
-            }
         }
 
         // Save updated checkpoint if we processed any events

--- a/Rickten.Projector/ProjectionRunner.cs
+++ b/Rickten.Projector/ProjectionRunner.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using Rickten.EventStore;
 
 namespace Rickten.Projector;
@@ -11,14 +10,11 @@ namespace Rickten.Projector;
 /// </remarks>
 /// <param name="eventStore">The event store to load events from.</param>
 /// <param name="projectionStore">The projection store for loading/saving checkpoints.</param>
-/// <param name="logger">Optional logger for diagnostic information.</param>
 public sealed class ProjectionRunner(IEventStore eventStore,
-                                      IProjectionStore projectionStore,
-                                      ILogger<ProjectionRunner>? logger = null)
+                                      IProjectionStore projectionStore)
 {
-    private readonly IProjectionStore _projectionStore  = projectionStore;
-    private readonly IEventStore _eventStore            = eventStore;
-    private readonly ILogger<ProjectionRunner>? _logger = logger;
+    private readonly IProjectionStore _projectionStore = projectionStore;
+    private readonly IEventStore _eventStore           = eventStore;
     /// <summary>
     /// Rebuilds a projection from scratch starting at a specific global position.
     /// Does not save checkpoints - caller is responsible for persistence.
@@ -125,11 +121,8 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             lastGlobalPosition = streamEvent.GlobalPosition;
         }
 
-        // Save updated checkpoint if we processed any events
-        if (lastGlobalPosition > fromGlobalPosition)
-        {
-            await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
-        }
+        // Save checkpoint (even if no events processed, record we're caught up)
+        await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
 
         return (view, lastGlobalPosition);
     }
@@ -175,11 +168,8 @@ public sealed class ProjectionRunner(IEventStore eventStore,
             lastGlobalPosition = streamEvent.GlobalPosition;
         }
 
-        // Save updated checkpoint if we processed any events
-        if (lastGlobalPosition > fromGlobalPosition)
-        {
-            await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
-        }
+        // Save checkpoint (even if no events processed, record we're caught up)
+        await _projectionStore.SaveProjectionAsync(projection.ProjectionName, lastGlobalPosition, view, @namespace, cancellationToken);
 
         return (view, lastGlobalPosition);
     }

--- a/Rickten.Projector/Rickten.Projector.csproj
+++ b/Rickten.Projector/Rickten.Projector.csproj
@@ -64,7 +64,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Rickten.Projector/Rickten.Projector.csproj
+++ b/Rickten.Projector/Rickten.Projector.csproj
@@ -62,4 +62,9 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Rickten.Projector/ServiceCollectionExtensions.cs
+++ b/Rickten.Projector/ServiceCollectionExtensions.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rickten.EventStore;
+
+namespace Rickten.Projector;
+
+/// <summary>
+/// Extension methods for registering projection services in an <see cref="IServiceCollection"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="ProjectionRunner"/> service with the dependency injection container.
+    /// The runner is registered as scoped to match the typical lifetime of its dependencies.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// ProjectionRunner requires <see cref="EventStore.IEventStore"/> and <see cref="IProjectionStore"/>
+    /// to be registered separately. These are typically registered through the Event Store setup:
+    /// </para>
+    /// <code>
+    /// services.AddEventStore(
+    ///     options => options.UseSqlServer(connectionString));
+    ///     
+    /// services.AddProjectionRunner();
+    /// </code>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Register projection runner
+    /// services.AddProjectionRunner();
+    /// 
+    /// // Then inject it into your services
+    /// public class MyProjectionService
+    /// {
+    ///     private readonly ProjectionRunner _runner;
+    ///     
+    ///     public MyProjectionService(ProjectionRunner runner)
+    ///     {
+    ///         _runner = runner;
+    ///     }
+    ///     
+    ///     public async Task ExecuteAsync()
+    ///     {
+    ///         var (view, position) = await _runner.CatchUpAsync(myProjection);
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddProjectionRunner(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Register ProjectionRunner as scoped to match the lifetime of its EF-backed dependencies
+        services.TryAddScoped<ProjectionRunner>();
+
+        return services;
+    }
+}

--- a/Rickten.Reactor.Tests/ReactionRunnerTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRunnerTests.cs
@@ -596,7 +596,7 @@ public class ReactionRunnerTests : IDisposable
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
 
         // Create runner with test logger
-        var projectionRunner = new ProjectionRunner(eventStore, projectionStore, null);
+        var projectionRunner = new ProjectionRunner(eventStore, projectionStore);
         var testRunner = new ReactionRunner(
             eventStore,
             projectionStore,

--- a/Rickten.Reactor.Tests/ReactionRunnerTests.cs
+++ b/Rickten.Reactor.Tests/ReactionRunnerTests.cs
@@ -596,9 +596,11 @@ public class ReactionRunnerTests : IDisposable
         var executor = new AggregateCommandExecutor<MembershipState, RecalculateMembershipCommand>(AggregateRepository, decider, registry);
 
         // Create runner with test logger
+        var projectionRunner = new ProjectionRunner(eventStore, projectionStore, null);
         var testRunner = new ReactionRunner(
             eventStore,
             projectionStore,
+            projectionRunner,
             reactionRepository,
             loggerFactory.CreateLogger<ReactionRunner>());
 

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -25,15 +25,18 @@ namespace Rickten.Reactor;
 /// </remarks>
 /// <param name="eventStore">The event store to load events from.</param>
 /// <param name="projectionStore">The projection store for managing projection state.</param>
+/// <param name="projectionRunner">The projection runner for managing projection state synchronization.</param>
 /// <param name="reactionRepository">The reaction repository for managing reaction checkpoints.</param>
 /// <param name="logger">Optional logger for diagnostic information.</param>
 public sealed class ReactionRunner(IEventStore eventStore,
                                    IProjectionStore projectionStore,
+                                   ProjectionRunner projectionRunner,
                                    IReactionRepository reactionRepository,
                                    ILogger<ReactionRunner>? logger = null)
 {
     private readonly IEventStore _eventStore = eventStore;
     private readonly IProjectionStore _projectionStore = projectionStore;
+    private readonly ProjectionRunner _projectionRunner = projectionRunner;
     private readonly IReactionRepository _reactionRepository = reactionRepository;
     private readonly ILogger<ReactionRunner>? _logger = logger;
 
@@ -104,9 +107,7 @@ public sealed class ReactionRunner(IEventStore eventStore,
                 reaction.Name, projectionPosition, reactionPosition, reactionPosition);
         }
 
-        (projectionView, projectionPosition) = await ProjectionRunner.SyncToPositionAsync(
-            _eventStore,
-            _projectionStore,
+        (projectionView, projectionPosition) = await _projectionRunner.SyncToPositionAsync(
             reaction.Projection,
             projectionView,
             projectionPosition,

--- a/Rickten.Reactor/ReactionRunner.cs
+++ b/Rickten.Reactor/ReactionRunner.cs
@@ -112,7 +112,6 @@ public sealed class ReactionRunner(IEventStore eventStore,
             projectionView,
             projectionPosition,
             reactionPosition,
-            reaction.Name,
             "reaction",
             cancellationToken);
 

--- a/Rickten.Reactor/ServiceCollectionExtensions.cs
+++ b/Rickten.Reactor/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rickten.Projector;
 using System.Reflection;
 
 namespace Rickten.Reactor;
@@ -58,6 +59,9 @@ public static class ServiceCollectionExtensions
                 "Pass assemblies explicitly (e.g., typeof(MyReaction).Assembly) or use a marker-type overload (e.g., AddReactions<TMarker>).",
                 nameof(assemblies));
         }
+
+        // Register ProjectionRunner as scoped (required by ReactionRunner)
+        services.TryAddScoped<ProjectionRunner>();
 
         // Register ReactionRunner as scoped to match the lifetime of its EF-backed dependencies
         services.TryAddScoped<ReactionRunner>();


### PR DESCRIPTION
## Summary
Converts `ProjectionRunner` from a static utility class to an instance-based service with dependency injection support, following the same pattern as `ReactionRunner`.

Closes #40

## Changes
- **Instance service conversion**: Converted `ProjectionRunner` to sealed instance class with constructor injection for `IEventStore` and `IProjectionStore`
- **DI infrastructure**: Added `ServiceCollectionExtensions.AddProjectionRunner()` for service registration (scoped lifetime)
- **Query optimization**: Added `untilGlobalPosition` parameter to `IEventStore.LoadAllAsync` for database-level filtering instead of application-level breaking
- **API simplification**: Removed `projectionName` parameter from methods - projections use their inherent names from `[Projection]` attribute, namespace provides context separation
- **Checkpoint improvements**: Always save checkpoints (even when no events processed) to prevent redundant queries for new/empty projections
- **Cleanup**: Removed unused `ILogger` dependency

## Updated Components
- `Rickten.Projector` - ProjectionRunner, ServiceCollectionExtensions
- `Rickten.EventStore` - IEventStore interface with untilGlobalPosition parameter
- `Rickten.EventStore.EntityFramework` - WHERE clause filtering implementation
- `Rickten.Reactor` - Updated to inject and use ProjectionRunner instance
- All tests updated and passing (15 Projector + 28 Reactor)

## Testing
All existing tests pass with behavior preserved. Query efficiency improved with database-level filtering.