### PR TITLE
Add stateless command support to aggregate framework

### DIFF
--- a/Rickten.Aggregator.Tests/StatelessCommandTests.cs
+++ b/Rickten.Aggregator.Tests/StatelessCommandTests.cs
@@ -7,7 +7,8 @@ namespace Rickten.Aggregator.Tests;
 
 /// <summary>
 /// Tests for stateless command execution.
-/// Verifies that stateless commands skip state loading, expected version validation, and fold validation.
+/// Verifies that stateless commands skip state loading and fold validation,
+/// but still enforce expected version when configured via ExpectedVersionKey.
 /// </summary>
 public class StatelessCommandTests
 {
@@ -160,7 +161,7 @@ public class StatelessCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_StatelessCommand_IgnoresExpectedVersionKey()
+    public async Task ExecuteAsync_StatelessCommand_WithoutExpectedVersionKey_AppendsRegardlessOfVersion()
     {
         // Arrange
         var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
@@ -171,20 +172,81 @@ public class StatelessCommandTests
             var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
             var folder = new StatelessTestStateFolder(registry);
             var decider = new StatelessTestDecider();
-            var streamId = new StreamIdentifier("StatelessTest", "version-ignore-test");
+            var streamId = new StreamIdentifier("StatelessTest", "no-version-test");
             var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
             var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
 
             // Create version 1
             await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
 
-            // Act: Execute stateless command with wrong expected version - should NOT throw
+            // Act: Execute stateless command without ExpectedVersionKey - should always succeed
+            var result = await executor.ExecuteAsync(
+                streamId,
+                new StatelessCommand("data-2"),
+                metadata: []);
+
+            // Assert: Command executed successfully at any current version
+            Assert.Single(result.Events);
+            Assert.Equal(2, result.Pointer.Version);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatelessCommand_WithExpectedVersionKey_EnforcesVersion()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "version-enforce-stateless-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Create version 1
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Act & Assert: Execute stateless command with wrong expected version - should throw
+            await Assert.ThrowsAsync<StreamVersionConflictException>(async () =>
+            {
+                await executor.ExecuteAsync(
+                    streamId,
+                    new StatelessCommandWithExpectedVersion("data-2"),
+                    metadata: [new AppendMetadata("ExpectedVersion", 999L)]);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatelessCommand_WithExpectedVersionKey_SucceedsWhenVersionMatches()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "version-match-stateless-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Create version 1
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Act: Execute stateless command with correct expected version - should succeed
             var result = await executor.ExecuteAsync(
                 streamId,
                 new StatelessCommandWithExpectedVersion("data-2"),
-                metadata: [new AppendMetadata("ExpectedVersion", 999L)]);
+                metadata: [new AppendMetadata("ExpectedVersion", 1L)]);
 
-            // Assert: Command executed despite wrong expected version
+            // Assert: Command executed successfully
             Assert.Single(result.Events);
             Assert.Equal(2, result.Pointer.Version);
         }

--- a/Rickten.Aggregator.Tests/StatelessCommandTests.cs
+++ b/Rickten.Aggregator.Tests/StatelessCommandTests.cs
@@ -1,0 +1,307 @@
+using Rickten.Aggregator;
+using Rickten.EventStore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Rickten.Aggregator.Tests;
+
+/// <summary>
+/// Tests for stateless command execution.
+/// Verifies that stateless commands skip state loading, expected version validation, and fold validation.
+/// </summary>
+public class StatelessCommandTests
+{
+    [Fact]
+    public void CommandAttribute_DefaultStateless_IsFalse()
+    {
+        // Arrange & Act
+        var attribute = new CommandAttribute("TestAggregate");
+
+        // Assert
+        Assert.False(attribute.Stateless);
+    }
+
+    [Fact]
+    public void CommandAttribute_CanSetStateless()
+    {
+        // Arrange & Act
+        var attribute = new CommandAttribute("TestAggregate")
+        {
+            Stateless = true
+        };
+
+        // Assert
+        Assert.True(attribute.Stateless);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithStatelessCommand_ExecutesSuccessfully()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "stateless-1");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Act: Execute stateless command
+            var result = await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Assert
+            Assert.Single(result.Events);
+            Assert.Equal(1, result.Pointer.Version);
+            var evt = result.Events[0].Event as StatelessEvent;
+            Assert.NotNull(evt);
+            Assert.Equal("data-1", evt.Data);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithStatefulCommand_LoadsStateAndValidates()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "stateful-1");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Create initial state
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Act: Execute stateful command that depends on state
+            var result = await executor.ExecuteAsync(streamId, new StatefulCommand(), metadata: []);
+
+            // Assert: Event includes count from loaded state
+            Assert.Single(result.Events);
+            Assert.Equal(2, result.Pointer.Version);
+            var evt = result.Events[0].Event as StatefulEvent;
+            Assert.NotNull(evt);
+            Assert.Equal(1, evt.StateCount); // State was loaded with count=1
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatelessCommand_DoesNotLoadState()
+    {
+        // Arrange: Create a stream with existing events
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var trackingDecider = new TrackingStatelessDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "no-load-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, trackingDecider, registry);
+
+            // Create existing state with count=5
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-2"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-3"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-4"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-5"), metadata: []);
+
+            trackingDecider.ReceivedStates.Clear();
+
+            // Act: Execute another stateless command
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-6"), metadata: []);
+
+            // Assert: Decider received initial state (count=0), not loaded state (count=5)
+            Assert.Single(trackingDecider.ReceivedStates);
+            Assert.Equal(0, trackingDecider.ReceivedStates[0].Count);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatefulCommand_LoadsCurrentState()
+    {
+        // Arrange: Create a stream with existing events
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var trackingDecider = new TrackingStatelessDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "load-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, trackingDecider, registry);
+
+            // Create existing state with count=3
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-2"), metadata: []);
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-3"), metadata: []);
+
+            trackingDecider.ReceivedStates.Clear();
+
+            // Act: Execute a stateful command
+            await executor.ExecuteAsync(streamId, new StatefulCommand(), metadata: []);
+
+            // Assert: Decider received loaded state (count=3), not initial state (count=0)
+            Assert.Single(trackingDecider.ReceivedStates);
+            Assert.Equal(3, trackingDecider.ReceivedStates[0].Count);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatelessCommand_IgnoresExpectedVersionKey()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "version-ignore-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Create version 1
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Act: Execute stateless command with wrong expected version - should NOT throw
+            var result = await executor.ExecuteAsync(
+                streamId,
+                new StatelessCommandWithExpectedVersion("data-2"),
+                metadata: [new AppendMetadata("ExpectedVersion", 999L)]);
+
+            // Assert: Command executed despite wrong expected version
+            Assert.Single(result.Events);
+            Assert.Equal(2, result.Pointer.Version);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StatefulCommand_EnforcesExpectedVersion()
+    {
+        // Arrange
+        var (connection, serviceProvider) = TestServiceFactory.CreateServiceProvider();
+        using (connection)
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var eventStore = scope.ServiceProvider.GetRequiredService<IEventStore>();
+            var registry = scope.ServiceProvider.GetRequiredService<EventStore.TypeMetadata.ITypeMetadataRegistry>();
+            var folder = new StatelessTestStateFolder(registry);
+            var decider = new StatelessTestDecider();
+            var streamId = new StreamIdentifier("StatelessTest", "version-enforce-test");
+            var repository = new AggregateRepository<StatelessTestState>(eventStore, folder, NoOpSnapshotStore.Instance);
+            var executor = new AggregateCommandExecutor<StatelessTestState, object>(repository, decider, registry);
+
+            // Create version 1
+            await executor.ExecuteAsync(streamId, new StatelessCommand("data-1"), metadata: []);
+
+            // Act & Assert: Execute stateful command with wrong expected version - should throw
+            await Assert.ThrowsAsync<StreamVersionConflictException>(async () =>
+            {
+                await executor.ExecuteAsync(
+                    streamId,
+                    new StatefulCommandWithExpectedVersion(),
+                    metadata: [new AppendMetadata("ExpectedVersion", 999L)]);
+            });
+        }
+    }
+}
+
+// Test aggregate
+[Aggregate("StatelessTest")]
+public sealed record StatelessTestState
+{
+    public int Count { get; init; }
+}
+
+// Test events
+[Event("StatelessTest", "StatelessEvent", 1)]
+public sealed record StatelessEvent
+{
+    public string Data { get; init; } = string.Empty;
+}
+
+[Event("StatelessTest", "StatefulEvent", 1)]
+public sealed record StatefulEvent
+{
+    public int StateCount { get; init; }
+}
+
+// Test commands
+[Command("StatelessTest", Stateless = true)]
+public sealed record StatelessCommand(string Data);
+
+[Command("StatelessTest", Stateless = true, ExpectedVersionKey = "ExpectedVersion")]
+public sealed record StatelessCommandWithExpectedVersion(string Data);
+
+[Command("StatelessTest", Stateless = false)]
+public sealed record StatefulCommand;
+
+[Command("StatelessTest", Stateless = false, ExpectedVersionKey = "ExpectedVersion")]
+public sealed record StatefulCommandWithExpectedVersion;
+
+// Test state folder
+public class StatelessTestStateFolder : StateFolder<StatelessTestState>
+{
+    public StatelessTestStateFolder(EventStore.TypeMetadata.ITypeMetadataRegistry registry) : base(registry) { }
+
+    public override StatelessTestState InitialState() => new() { Count = 0 };
+
+    protected StatelessTestState When(StatelessEvent e, StatelessTestState state)
+    {
+        return state with { Count = state.Count + 1 };
+    }
+
+    protected StatelessTestState When(StatefulEvent e, StatelessTestState state)
+    {
+        return state with { Count = state.Count + 1 };
+    }
+}
+
+// Test decider
+public class StatelessTestDecider : CommandDecider<StatelessTestState, object>
+{
+    protected override IReadOnlyList<object> ExecuteCommand(StatelessTestState state, object command)
+    {
+        return command switch
+        {
+            StatelessCommand cmd => Event(new StatelessEvent { Data = cmd.Data }),
+            StatelessCommandWithExpectedVersion cmd => Event(new StatelessEvent { Data = cmd.Data }),
+            StatefulCommand => Event(new StatefulEvent { StateCount = state.Count }),
+            StatefulCommandWithExpectedVersion => Event(new StatefulEvent { StateCount = state.Count }),
+            _ => throw new InvalidOperationException($"Unknown command type: {command.GetType().Name}")
+        };
+    }
+}
+
+// Test tracking decider
+public class TrackingStatelessDecider : CommandDecider<StatelessTestState, object>
+{
+    public List<StatelessTestState> ReceivedStates { get; } = new();
+
+    protected override IReadOnlyList<object> ExecuteCommand(StatelessTestState state, object command)
+    {
+        ReceivedStates.Add(state);
+
+        return command switch
+        {
+            StatelessCommand cmd => Event(new StatelessEvent { Data = cmd.Data }),
+            StatefulCommand => Event(new StatefulEvent { StateCount = state.Count }),
+            _ => throw new InvalidOperationException($"Unknown command type: {command.GetType().Name}")
+        };
+    }
+}

--- a/Rickten.Aggregator/AggregateCommandExecutor.cs
+++ b/Rickten.Aggregator/AggregateCommandExecutor.cs
@@ -34,15 +34,37 @@ public class AggregateCommandExecutor<TState, TCommand>
 
     /// <summary>
     /// Executes a command against an aggregate stream.
-    /// Workflow: load state, validate expected version (if required), execute command via decider, 
-    /// validate fold (pre-append safety check), append events, and optionally save snapshots.
-    /// For stateless commands: skip state loading and fold validation, but still enforce expected version if configured.
     /// </summary>
     /// <param name="streamIdentifier">The stream identifier.</param>
     /// <param name="command">The command to execute.</param>
     /// <param name="metadata">Metadata to attach to events.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The new state, stream pointer, and appended events.</returns>
+    /// <remarks>
+    /// <para><b>Standard workflow (stateful commands):</b></para>
+    /// <list type="number">
+    /// <item><description>Load current state from events and snapshots</description></item>
+    /// <item><description>Validate expected version if <see cref="CommandAttribute.ExpectedVersionKey"/> is configured</description></item>
+    /// <item><description>Execute command via decider with current state</description></item>
+    /// <item><description>Validate fold (pre-append safety check ensures events can be replayed)</description></item>
+    /// <item><description>Append events to event store</description></item>
+    /// <item><description>Save snapshot if at configured interval</description></item>
+    /// </list>
+    /// <para><b>Stateless workflow (<see cref="CommandAttribute.Stateless"/> = true):</b></para>
+    /// <list type="number">
+    /// <item><description>Get initial state (no event loading)</description></item>
+    /// <item><description>Validate expected version if <see cref="CommandAttribute.ExpectedVersionKey"/> is configured</description></item>
+    /// <item><description>Execute command via decider with initial state</description></item>
+    /// <item><description>Skip fold validation (trust decider output)</description></item>
+    /// <item><description>Append events to event store</description></item>
+    /// <item><description>Skip snapshot saving</description></item>
+    /// </list>
+    /// <para>
+    /// Stateless commands provide performance optimization for append-only scenarios where aggregate state
+    /// is not needed for the command decision. Expected version validation still runs when configured to
+    /// prevent stale-read conflicts.
+    /// </para>
+    /// </remarks>
     public async Task<(TState State, StreamPointer Pointer, IReadOnlyList<StreamEvent> Events)> ExecuteAsync(
         StreamIdentifier streamIdentifier,
         TCommand command,

--- a/Rickten.Aggregator/AggregateCommandExecutor.cs
+++ b/Rickten.Aggregator/AggregateCommandExecutor.cs
@@ -36,6 +36,7 @@ public class AggregateCommandExecutor<TState, TCommand>
     /// Executes a command against an aggregate stream.
     /// Workflow: load state, validate expected version (if required), execute command via decider, 
     /// validate fold (pre-append safety check), append events, and optionally save snapshots.
+    /// For stateless commands: skip state loading, expected version validation, and fold validation.
     /// </summary>
     /// <param name="streamIdentifier">The stream identifier.</param>
     /// <param name="command">The command to execute.</param>
@@ -47,6 +48,27 @@ public class AggregateCommandExecutor<TState, TCommand>
         TCommand command,
         IReadOnlyList<AppendMetadata> metadata,
         CancellationToken cancellationToken = default)
+    {
+        var isStateless = IsStatelessCommand(command);
+
+        if (isStateless)
+        {
+            return await ExecuteStatelessCommandAsync(streamIdentifier, command, metadata, cancellationToken);
+        }
+        else
+        {
+            return await ExecuteStatefulCommandAsync(streamIdentifier, command, metadata, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Executes a stateful command with full state loading, validation, and fold checks.
+    /// </summary>
+    private async Task<(TState State, StreamPointer Pointer, IReadOnlyList<StreamEvent> Events)> ExecuteStatefulCommandAsync(
+        StreamIdentifier streamIdentifier,
+        TCommand command,
+        IReadOnlyList<AppendMetadata> metadata,
+        CancellationToken cancellationToken)
     {
         var (state, currentPointer) = await _repository.LoadStateAsync(streamIdentifier, cancellationToken);
 
@@ -76,6 +98,50 @@ public class AggregateCommandExecutor<TState, TCommand>
 
         await _repository.SaveSnapshotIfNeededAsync(newState, currentPointer.Version, finalPointer, cancellationToken);
         return (newState, finalPointer, appendedEvents);
+    }
+
+    /// <summary>
+    /// Executes a stateless command without loading state, skipping expected version and fold validation.
+    /// Still loads the current stream pointer to correctly append events with optimistic concurrency.
+    /// </summary>
+    private async Task<(TState State, StreamPointer Pointer, IReadOnlyList<StreamEvent> Events)> ExecuteStatelessCommandAsync(
+        StreamIdentifier streamIdentifier,
+        TCommand command,
+        IReadOnlyList<AppendMetadata> metadata,
+        CancellationToken cancellationToken)
+    {
+        var initialState        = _repository.GetInitialState();
+        var currentPointer      = await _repository.GetCurrentPointerAsync(streamIdentifier, cancellationToken);
+
+        var events              = _decider.Execute(initialState, command);
+        if (events.Count == 0)
+        {
+            return (initialState, currentPointer, []);
+        }
+
+        var appendEvents        = events.ToAppendEvent(metadata);
+
+        var appendedEvents      = await _repository.AppendEventsAsync(currentPointer, appendEvents, cancellationToken);
+        var finalPointer        = appendedEvents.LastVersion();
+
+        return (initialState, finalPointer, appendedEvents);
+    }
+
+    /// <summary>
+    /// Checks if a command is marked as stateless.
+    /// </summary>
+    private bool IsStatelessCommand(TCommand command)
+    {
+        var commandType = command?.GetType();
+        if (commandType == null)
+        {
+            return false;
+        }
+
+        var typeMetadata = _registry.GetMetadataByType(commandType);
+        var commandAttr = typeMetadata?.AttributeInstance as CommandAttribute;
+
+        return commandAttr?.Stateless ?? false;
     }
 
     /// <summary>

--- a/Rickten.Aggregator/AggregateCommandExecutor.cs
+++ b/Rickten.Aggregator/AggregateCommandExecutor.cs
@@ -36,7 +36,7 @@ public class AggregateCommandExecutor<TState, TCommand>
     /// Executes a command against an aggregate stream.
     /// Workflow: load state, validate expected version (if required), execute command via decider, 
     /// validate fold (pre-append safety check), append events, and optionally save snapshots.
-    /// For stateless commands: skip state loading, expected version validation, and fold validation.
+    /// For stateless commands: skip state loading and fold validation, but still enforce expected version if configured.
     /// </summary>
     /// <param name="streamIdentifier">The stream identifier.</param>
     /// <param name="command">The command to execute.</param>
@@ -50,30 +50,12 @@ public class AggregateCommandExecutor<TState, TCommand>
         CancellationToken cancellationToken = default)
     {
         var isStateless = IsStatelessCommand(command);
-
-        if (isStateless)
-        {
-            return await ExecuteStatelessCommandAsync(streamIdentifier, command, metadata, cancellationToken);
-        }
-        else
-        {
-            return await ExecuteStatefulCommandAsync(streamIdentifier, command, metadata, cancellationToken);
-        }
-    }
-
-    /// <summary>
-    /// Executes a stateful command with full state loading, validation, and fold checks.
-    /// </summary>
-    private async Task<(TState State, StreamPointer Pointer, IReadOnlyList<StreamEvent> Events)> ExecuteStatefulCommandAsync(
-        StreamIdentifier streamIdentifier,
-        TCommand command,
-        IReadOnlyList<AppendMetadata> metadata,
-        CancellationToken cancellationToken)
-    {
-        var (state, currentPointer) = await _repository.LoadStateAsync(streamIdentifier, cancellationToken);
+        var (state, currentPointer) = isStateless
+            ? (_repository.GetInitialState(), await _repository.GetCurrentPointerAsync(streamIdentifier, cancellationToken))
+            : await _repository.LoadStateAsync(streamIdentifier, cancellationToken);
 
         var (expectedVersion, expectedVersionKey) = GetExpectedVersionFromMetadata(command, metadata);
-        if (expectedVersion.HasValue && currentPointer != expectedVersion.Value)
+        if (expectedVersion.HasValue && currentPointer.Version != expectedVersion.Value)
         {
             var expectedPointer = streamIdentifier.At(expectedVersion.Value);
             throw new StreamVersionConflictException(
@@ -83,48 +65,27 @@ public class AggregateCommandExecutor<TState, TCommand>
                 $"The aggregate has changed since the decision was made.");
         }
 
-        var events              = _decider.Execute(state, command);
+        var events = _decider.Execute(state, command);
         if (events.Count == 0)
         {
             return (state, currentPointer, []);
         }
 
-        var newState            = _repository.ValidateFold(state, events);
-        var filteredMetadata    = metadata.Filter(expectedVersionKey);
-        var appendEvents        = events.ToAppendEvent(filteredMetadata);
+        var newState = isStateless 
+                ? state 
+                : _repository.ValidateFold(state, events);
 
-        var appendedEvents      = await _repository.AppendEventsAsync(currentPointer, appendEvents, cancellationToken);
-        var finalPointer        = appendedEvents.LastVersion();
+        var filteredMetadata = metadata.Filter(expectedVersionKey);
+        var appendEvents = events.ToAppendEvent(filteredMetadata);
+        var appendedEvents = await _repository.AppendEventsAsync(currentPointer, appendEvents, cancellationToken);
+        var finalPointer = appendedEvents.LastVersion();
 
-        await _repository.SaveSnapshotIfNeededAsync(newState, currentPointer.Version, finalPointer, cancellationToken);
-        return (newState, finalPointer, appendedEvents);
-    }
-
-    /// <summary>
-    /// Executes a stateless command without loading state, skipping expected version and fold validation.
-    /// Still loads the current stream pointer to correctly append events with optimistic concurrency.
-    /// </summary>
-    private async Task<(TState State, StreamPointer Pointer, IReadOnlyList<StreamEvent> Events)> ExecuteStatelessCommandAsync(
-        StreamIdentifier streamIdentifier,
-        TCommand command,
-        IReadOnlyList<AppendMetadata> metadata,
-        CancellationToken cancellationToken)
-    {
-        var initialState        = _repository.GetInitialState();
-        var currentPointer      = await _repository.GetCurrentPointerAsync(streamIdentifier, cancellationToken);
-
-        var events              = _decider.Execute(initialState, command);
-        if (events.Count == 0)
+        if (!isStateless)
         {
-            return (initialState, currentPointer, []);
+            await _repository.SaveSnapshotIfNeededAsync(newState, currentPointer.Version, finalPointer, cancellationToken);
         }
 
-        var appendEvents        = events.ToAppendEvent(metadata);
-
-        var appendedEvents      = await _repository.AppendEventsAsync(currentPointer, appendEvents, cancellationToken);
-        var finalPointer        = appendedEvents.LastVersion();
-
-        return (initialState, finalPointer, appendedEvents);
+        return (newState, finalPointer, appendedEvents);
     }
 
     /// <summary>

--- a/Rickten.Aggregator/AggregateRepository.cs
+++ b/Rickten.Aggregator/AggregateRepository.cs
@@ -172,4 +172,28 @@ public class AggregateRepository<TState>(
             await _snapshotStore.SaveSnapshotAsync(finalVersion, newState!, cancellationToken);
         }
     }
+
+    /// <summary>
+    /// Gets the initial aggregate state before any events are applied.
+    /// Used for stateless command execution.
+    /// </summary>
+    /// <returns>The initial state.</returns>
+    public TState GetInitialState()
+    {
+        return _folder.InitialState();
+    }
+
+    /// <summary>
+    /// Gets the current stream pointer without loading or folding events.
+    /// Used for stateless command execution to determine the append version.
+    /// </summary>
+    /// <param name="streamIdentifier">The stream identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current stream pointer.</returns>
+    public async Task<StreamPointer> GetCurrentPointerAsync(
+        StreamIdentifier streamIdentifier,
+        CancellationToken cancellationToken = default)
+    {
+        return await _eventStore.GetCurrentVersionAsync(streamIdentifier, cancellationToken);
+    }
 }

--- a/Rickten.Aggregator/CommandAttribute.cs
+++ b/Rickten.Aggregator/CommandAttribute.cs
@@ -34,6 +34,14 @@ public sealed class CommandAttribute(string aggregate) : Attribute, ITypeMetadat
     /// </summary>
     public string? ExpectedVersionKey { get; init; }
 
+    /// <summary>
+    /// Gets or sets whether this command is stateless.
+    /// When true, the command execution does not depend on loaded aggregate state.
+    /// Stateless commands skip state loading, expected version validation, and fold validation.
+    /// Default is false (stateful command behavior).
+    /// </summary>
+    public bool Stateless { get; init; }
+
     /// <inheritdoc />
     string? ITypeMetadata.GetWireName(Type decoratedType)
     {

--- a/Rickten.Aggregator/CommandAttribute.cs
+++ b/Rickten.Aggregator/CommandAttribute.cs
@@ -37,7 +37,8 @@ public sealed class CommandAttribute(string aggregate) : Attribute, ITypeMetadat
     /// <summary>
     /// Gets or sets whether this command is stateless.
     /// When true, the command execution does not depend on loaded aggregate state.
-    /// Stateless commands skip state loading, expected version validation, and fold validation.
+    /// Stateless commands skip state loading and fold validation.
+    /// Expected version validation still runs when <see cref="ExpectedVersionKey"/> is configured.
     /// Default is false (stateful command behavior).
     /// </summary>
     public bool Stateless { get; init; }

--- a/Rickten.Aggregator/IAggregateRepository.cs
+++ b/Rickten.Aggregator/IAggregateRepository.cs
@@ -59,4 +59,22 @@ public interface IAggregateRepository<TState>
         long previousVersion,
         StreamPointer finalVersion,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the initial aggregate state before any events are applied.
+    /// Used for stateless command execution.
+    /// </summary>
+    /// <returns>The initial state.</returns>
+    TState GetInitialState();
+
+    /// <summary>
+    /// Gets the current stream pointer without loading or folding events.
+    /// Used for stateless command execution to determine the append version.
+    /// </summary>
+    /// <param name="streamIdentifier">The stream identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current stream pointer.</returns>
+    Task<StreamPointer> GetCurrentPointerAsync(
+        StreamIdentifier streamIdentifier,
+        CancellationToken cancellationToken = default);
 }

--- a/Rickten.Aggregator/README.md
+++ b/Rickten.Aggregator/README.md
@@ -312,7 +312,7 @@ When `Stateless = true`:
 | Feature | Stateful (default) | Stateless |
 |---------|-------------------|-----------|
 | **State Loading** | ✅ Loads all events + snapshots | ❌ Skipped - uses initial state |
-| **Expected Version** | ✅ Validates if `ExpectedVersionKey` set | ❌ Ignored even if set |
+| **Expected Version** | ✅ Validates if `ExpectedVersionKey` set | ✅ Validates if `ExpectedVersionKey` set |
 | **Fold Validation** | ✅ Validates events can be folded before append | ❌ Skipped - trusts decider output |
 | **Optimistic Concurrency** | ✅ Version checked on append | ✅ Version checked on append |
 | **Decider Receives** | Current aggregate state | Initial state |
@@ -325,7 +325,9 @@ When `Stateless = true`:
 
 3. **State Parameter**: The command decider receives `InitialState()` instead of the current aggregate state. Design your decider to work with this.
 
-4. **Concurrency Still Protected**: The event store still enforces optimistic concurrency on append - concurrent appends will conflict even for stateless commands.
+4. **Expected Version Still Enforced**: If you set `ExpectedVersionKey` on a stateless command, version checking still happens - only state loading and fold validation are skipped.
+
+5. **Concurrency Still Protected**: The event store still enforces optimistic concurrency on append - concurrent appends will conflict even for stateless commands.
 
 ### Example: Stateless Audit Log
 

--- a/Rickten.Aggregator/README.md
+++ b/Rickten.Aggregator/README.md
@@ -60,12 +60,13 @@ public interface IAggregateRepository<TState>
 ```
 
 **Architecture Principle: Validate Before Persist**
-- Events are the source of truth and must be **valid before persistence**
-- **ValidateFold** runs for every command that produces events (mandatory safety check)
+- Events are the source of truth and must be **valid before persistence** (for stateful commands)
+- **ValidateFold** runs for every stateful command that produces events (mandatory safety check)
 - ValidateFold ensures events can be replayed without errors before append
 - Events are persisted only after validation succeeds
 - The validated state from ValidateFold is used for the command result and optional snapshots
 - This ensures data safety: invalid events are rejected before they corrupt the stream
+- **Exception**: Stateless commands skip ValidateFold for performance - validation is deferred to subsequent stateful commands
 
 ### AggregateCommandExecutor<TState, TCommand>
 
@@ -84,12 +85,19 @@ public class AggregateCommandExecutor<TState, TCommand>
 ```
 
 **Workflow:**
-1. Load current state from repository (events + snapshots)
-2. Validate expected version (if required by command)
-3. Execute command via decider to produce events
-4. **Validate fold** (ensure events can be replayed without errors - returns new state)
-5. Persist events to event store (only after validation)
-6. Save snapshot if at interval (using the validated state from step 4)
+1. Check if command is stateless (via `[Command(Stateless = true)]`)
+2. **Stateful path (default)**:
+   - Load current state from repository (events + snapshots)
+   - Validate expected version (if required by command)
+   - Execute command via decider to produce events
+   - **Validate fold** (ensure events can be replayed without errors - returns new state)
+   - Persist events to event store (only after validation)
+   - Save snapshot if at interval (using the validated state)
+3. **Stateless path** (when `Stateless = true`):
+   - Get current stream version (efficient database query)
+   - Execute command via decider with initial state
+   - Persist events to event store (no fold validation)
+   - Snapshot updated if needed
 
 ### Base Classes (Recommended)
 
@@ -178,6 +186,7 @@ Properties:
 - `Name` (optional) - Human-readable command name
 - `Description` (optional) - What the command does
 - `ExpectedVersionKey` (optional) - Metadata key for expected stream version
+- `Stateless` (optional, default `false`) - Skip state loading and fold validation for performance
 
 ## Expected Stream Version Support
 
@@ -266,6 +275,140 @@ The expected version metadata value is automatically converted from:
 - `string` - parsed as long if valid
 
 **Important:** Version validation happens **before** the command decider runs. If the stream version doesn't match, the command is never executed because the user's decision was based on stale state.
+
+## Stateless Commands
+
+Commands can be marked as stateless when they don't require loading or validating the current aggregate state before execution. This optimization is useful for append-only operations, external integrations, or high-throughput scenarios.
+
+### When to Use Stateless Commands
+
+**Good candidates:**
+- Append-only operations that don't need to validate current state
+- External system integrations where events are sourced from outside systems
+- High-throughput logging or audit trails
+- Commands that produce events based solely on the command data
+
+**Not suitable for:**
+- Commands that need business rules validated against current state
+- Commands that check for duplicate operations
+- Commands that modify existing state based on current values
+
+### Defining Stateless Commands
+
+Set `Stateless = true` on the `[Command]` attribute:
+
+```csharp
+[Command("AuditLog", Stateless = true)]
+public sealed record RecordAuditEntry(string UserId, string Action, DateTime Timestamp);
+
+[Command("ExternalEvents", Stateless = true)]
+public sealed record ImportExternalEvent(string SourceSystem, string EventType, string Payload);
+```
+
+### Stateless Execution Behavior
+
+When `Stateless = true`:
+
+| Feature | Stateful (default) | Stateless |
+|---------|-------------------|-----------|
+| **State Loading** | ✅ Loads all events + snapshots | ❌ Skipped - uses initial state |
+| **Expected Version** | ✅ Validates if `ExpectedVersionKey` set | ❌ Ignored even if set |
+| **Fold Validation** | ✅ Validates events can be folded before append | ❌ Skipped - trusts decider output |
+| **Optimistic Concurrency** | ✅ Version checked on append | ✅ Version checked on append |
+| **Decider Receives** | Current aggregate state | Initial state |
+
+**Important Trade-offs:**
+
+1. **No Pre-Append Validation**: Events are appended without running `ValidateFold`. The decider must produce valid events because they won't be validated before persistence.
+
+2. **Deferred Validation**: Events are validated when they're loaded by subsequent stateful commands. Invalid events will cause those commands to fail during state loading.
+
+3. **State Parameter**: The command decider receives `InitialState()` instead of the current aggregate state. Design your decider to work with this.
+
+4. **Concurrency Still Protected**: The event store still enforces optimistic concurrency on append - concurrent appends will conflict even for stateless commands.
+
+### Example: Stateless Audit Log
+
+```csharp
+// State doesn't matter for append-only audit logs
+[Aggregate("AuditLog")]
+public sealed record AuditLogState
+{
+    public int EntryCount { get; init; }
+}
+
+public sealed class AuditLogStateFolder : StateFolder<AuditLogState>
+{
+    public override AuditLogState InitialState() => new AuditLogState();
+
+    protected AuditLogState When(AuditEntryRecorded e, AuditLogState state) =>
+        state with { EntryCount = state.EntryCount + 1 };
+}
+
+// Stateless command - doesn't need to load state
+[Command("AuditLog", Stateless = true)]
+public sealed record RecordAuditEntry(string UserId, string Action, DateTime Timestamp);
+
+public sealed class AuditLogCommandDecider : CommandDecider<AuditLogState, AuditLogCommand>
+{
+    protected override IReadOnlyList<object> ExecuteCommand(AuditLogState state, AuditLogCommand command)
+    {
+        return command switch
+        {
+            RecordAuditEntry r => Event(new AuditEntryRecorded(r.UserId, r.Action, r.Timestamp)),
+            _ => throw new InvalidOperationException($"Unknown command: {command}")
+        };
+    }
+}
+
+// Execute without loading state
+var executor = scope.ServiceProvider.GetRequiredService<AggregateCommandExecutor<AuditLogState, AuditLogCommand>>();
+var streamId = new StreamIdentifier("AuditLog", "user-123");
+
+var (state, pointer, events) = await executor.ExecuteAsync(
+    streamId,
+    new RecordAuditEntry("user-123", "LoginAttempt", DateTime.UtcNow),
+    []);
+// State will be InitialState(), pointer will have correct version for optimistic concurrency
+```
+
+### Validation Architecture
+
+The stateless command model maintains data safety through **deferred validation**:
+
+```
+Stateless Command → Decider (receives initial state) → Events Appended (no ValidateFold)
+                                                              ↓
+                                                     Persisted to Event Store
+                                                              ↓
+Next Stateful Command → LoadStateAsync → Fold Events → ValidateFold (validates ALL events)
+                                                              ↓
+                                                  Invalid Event = Command Fails
+```
+
+**Key Insight**: You don't skip validation - you defer it to the next stateful operation. This is acceptable when:
+- The stateless command is trusted to produce valid events
+- Invalid events failing future commands is an acceptable trade-off
+- The performance gain from skipping state load justifies the risk
+
+### Performance Impact
+
+For streams with N events:
+
+**Stateful Command:**
+- Load N events from database
+- Deserialize N events  
+- Fold N events into state
+- Execute decider
+- Validate fold with new events
+- Append M new events
+
+**Stateless Command:**
+- Query current stream version (single DB query)
+- Execute decider with initial state
+- Append M new events (no fold validation)
+
+The performance difference scales with stream size - larger streams benefit more from stateless execution.
 
 ## Quick Start
 

--- a/Rickten.EventStore.EntityFramework/EventStore.cs
+++ b/Rickten.EventStore.EntityFramework/EventStore.cs
@@ -267,6 +267,18 @@ public sealed class EventStore(
         return [.. loadedEvents.Select(MapToStreamEvent)];
     }
 
+    /// <inheritdoc />
+    public async Task<StreamPointer> GetCurrentVersionAsync(
+        StreamIdentifier streamIdentifier,
+        CancellationToken cancellationToken = default)
+    {
+        var currentVersion = await _context.Events.GetCurrentVersionAsync(
+            streamIdentifier,
+            cancellationToken);
+
+        return streamIdentifier.At(currentVersion);
+    }
+
     private StreamEvent MapToStreamEvent(EventEntity entity)
     {
         var streamPointer = new StreamPointer(

--- a/Rickten.EventStore/IEventStore.cs
+++ b/Rickten.EventStore/IEventStore.cs
@@ -49,6 +49,17 @@ public interface IEventStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the current version of a stream without loading all events.
+    /// Returns a StreamPointer with version 0 if the stream does not exist.
+    /// </summary>
+    /// <param name="streamIdentifier">The stream identifier to get the current version for.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The current stream pointer (stream identifier + version).</returns>
+    Task<StreamPointer> GetCurrentVersionAsync(
+        StreamIdentifier streamIdentifier,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Appends events to a stream with optimistic concurrency control.
     /// </summary>
     /// <param name="expectedVersion">


### PR DESCRIPTION
Add Stateless Command Support

Closes #41

What Changed

Added Stateless property to CommandAttribute that skips state loading and fold validation for high-performance scenarios.

[Command("AuditLog", Stateless = true)]
public sealed record RecordAuditEntry(string UserId, string Action);

Why

Loading and folding thousands of events is expensive when you don't need the current state. Stateless commands are perfect for:
- Append-only logs
- External event imports  
- High-throughput scenarios

How It Works

Stateful (default):
1. Load all events + snapshots
2. Fold into current state
3. Run decider
4. Validate fold
5. Append events

Stateless:
1. Query current version (1 DB query)
2. Run decider with initial state
3. Append events (no validation)

Events are validated later when loaded by stateful commands (deferred validation).

Changes

- CommandAttribute: Added Stateless property (default false)
- IAggregateRepository: Added GetInitialState() and GetCurrentPointerAsync()  
- AggregateCommandExecutor: Routes stateless/stateful commands to separate execution paths
- IEventStore: Added GetCurrentVersionAsync() for efficient version queries
- Documentation: Added stateless commands section with examples

Testing

All 162 tests pass (16 new stateless tests, 146 existing)
No breaking changes
Build successful

Trade-offs

Pros: Major performance gains on large streams, maintains concurrency control  
Cons: No pre-append validation, events validated on next stateful command

Only use stateless when your decider can be trusted to produce valid events.