### PR TITLE
Add optional schema support to EventStoreDbContext for multi-tenant s…

### DIFF
--- a/Rickten.EventStore.EntityFramework/EventStoreDbContext.cs
+++ b/Rickten.EventStore.EntityFramework/EventStoreDbContext.cs
@@ -8,13 +8,17 @@ namespace Rickten.EventStore.EntityFramework;
 /// </summary>
 public sealed class EventStoreDbContext : DbContext
 {
+    private readonly string? _schema;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStoreDbContext"/> class.
     /// </summary>
     /// <param name="options">The options for this context.</param>
-    public EventStoreDbContext(DbContextOptions<EventStoreDbContext> options)
+    /// <param name="schema">Optional database schema name. If not provided, uses the provider's default schema.</param>
+    public EventStoreDbContext(DbContextOptions<EventStoreDbContext> options, string? schema = null)
         : base(options)
     {
+        _schema = schema;
     }
 
     /// <summary>
@@ -41,6 +45,12 @@ public sealed class EventStoreDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        // Apply custom schema if provided
+        if (!string.IsNullOrWhiteSpace(_schema))
+        {
+            modelBuilder.HasDefaultSchema(_schema);
+        }
 
         var utcNowSql = GetUtcNowSql();
 

--- a/Rickten.EventStore.EntityFramework/EventStoreSchemaOptions.cs
+++ b/Rickten.EventStore.EntityFramework/EventStoreSchemaOptions.cs
@@ -1,0 +1,7 @@
+namespace Rickten.EventStore.EntityFramework;
+
+/// <summary>
+/// Options for configuring the event store database schema.
+/// </summary>
+/// <param name="Schema">The database schema name (e.g., "users", "orders"). If null or empty, uses the provider's default schema.</param>
+public sealed record EventStoreSchemaOptions(string Schema);

--- a/Rickten.EventStore.EntityFramework/ServiceCollectionExtensions.cs
+++ b/Rickten.EventStore.EntityFramework/ServiceCollectionExtensions.cs
@@ -36,6 +36,42 @@ public static class ServiceCollectionExtensions
         Action<DbContextOptionsBuilder> optionsAction,
         params Assembly[] assemblies)
     {
+        return AddEventStoreCore(services, optionsAction, schema: null, assemblies);
+    }
+
+    /// <summary>
+    /// Adds all Event Store services with optional schema support for multi-tenant and bounded context scenarios.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> for the Event Store.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
+    /// <param name="assemblies">The assemblies to scan for attributed types. Must contain at least one assembly.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentException">Thrown when no assemblies are provided.</exception>
+    /// <example>
+    /// <code>
+    /// // With custom schema for multi-tenant or bounded context scenarios
+    /// services.AddEventStore(
+    ///     options => options.UseNpgsql(connectionString),
+    ///     schema: "orders",
+    ///     assemblies: new[] { typeof(OrderEvent).Assembly });
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddEventStore(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> optionsAction,
+        string? schema,
+        Assembly[] assemblies)
+    {
+        return AddEventStoreCore(services, optionsAction, schema, assemblies);
+    }
+
+    private static IServiceCollection AddEventStoreCore(
+        IServiceCollection services,
+        Action<DbContextOptionsBuilder> optionsAction,
+        string? schema,
+        Assembly[] assemblies)
+    {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(optionsAction);
 
@@ -80,8 +116,25 @@ public static class ServiceCollectionExtensions
             return builder.Build();
         });
 
+        // Register schema options if provided
+        if (!string.IsNullOrWhiteSpace(schema))
+        {
+            services.TryAddSingleton(new EventStoreSchemaOptions(schema));
+        }
+
         // Use TryAddDbContext to prevent duplicate registrations
-        services.AddDbContext<EventStoreDbContext>(optionsAction);
+        services.AddDbContext<EventStoreDbContext>((sp, options) =>
+        {
+            optionsAction(options);
+        }, contextLifetime: ServiceLifetime.Scoped);
+
+        // Override the EventStoreDbContext factory to pass schema
+        services.AddScoped<EventStoreDbContext>(sp =>
+        {
+            var schemaOptions = sp.GetService<EventStoreSchemaOptions>();
+            var options = sp.GetRequiredService<DbContextOptions<EventStoreDbContext>>();
+            return new EventStoreDbContext(options, schemaOptions?.Schema);
+        });
 
         // Register WireTypeSerializer as a scoped service
         services.TryAddScoped<Serialization.WireTypeSerializer>();
@@ -101,6 +154,7 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker">A type from the assembly to scan for attributed types.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> for the Event Store.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     /// <example>
     /// <code>
@@ -113,9 +167,10 @@ public static class ServiceCollectionExtensions
     /// </example>
     public static IServiceCollection AddEventStore<TMarker>(
         this IServiceCollection services,
-        Action<DbContextOptionsBuilder> optionsAction)
+        Action<DbContextOptionsBuilder> optionsAction,
+        string? schema = null)
     {
-        return services.AddEventStore(optionsAction, typeof(TMarker).Assembly);
+        return services.AddEventStore(optionsAction, schema, new[] { typeof(TMarker).Assembly });
     }
 
     /// <summary>
@@ -125,12 +180,14 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker2">A type from the second assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> for the Event Store.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStore<TMarker1, TMarker2>(
         this IServiceCollection services,
-        Action<DbContextOptionsBuilder> optionsAction)
+        Action<DbContextOptionsBuilder> optionsAction,
+        string? schema = null)
     {
-        return services.AddEventStore(optionsAction, typeof(TMarker1).Assembly, typeof(TMarker2).Assembly);
+        return services.AddEventStore(optionsAction, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly });
     }
 
     /// <summary>
@@ -141,12 +198,14 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker3">A type from the third assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="optionsAction">An action to configure the <see cref="DbContextOptionsBuilder"/> for the Event Store.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStore<TMarker1, TMarker2, TMarker3>(
         this IServiceCollection services,
-        Action<DbContextOptionsBuilder> optionsAction)
+        Action<DbContextOptionsBuilder> optionsAction,
+        string? schema = null)
     {
-        return services.AddEventStore(optionsAction, typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly);
+        return services.AddEventStore(optionsAction, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly });
     }
 
     /// <summary>
@@ -168,13 +227,37 @@ public static class ServiceCollectionExtensions
         string databaseName,
         params Assembly[] assemblies)
     {
+        return AddEventStoreInMemory(services, databaseName, schema: null, assemblies);
+    }
+
+    /// <summary>
+    /// Adds all Event Store services using an in-memory database with optional schema support.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="databaseName">The name of the in-memory database.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
+    /// <param name="assemblies">The assemblies to scan for attributed types. Must contain at least one assembly.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentException">Thrown when no assemblies are provided.</exception>
+    /// <example>
+    /// <code>
+    /// // With custom schema
+    /// services.AddEventStoreInMemory("TestDb", schema: "test_schema", assemblies: new[] { typeof(MyEvent).Assembly });
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddEventStoreInMemory(
+        this IServiceCollection services,
+        string databaseName,
+        string? schema,
+        Assembly[] assemblies)
+    {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
 
         return services.AddEventStore(options =>
         {
             options.UseInMemoryDatabase(databaseName);
-        }, assemblies);
+        }, schema, assemblies);
     }
 
     /// <summary>
@@ -183,12 +266,14 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker">A type from the assembly to scan for attributed types.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="databaseName">The name of the in-memory database.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreInMemory<TMarker>(
         this IServiceCollection services,
-        string databaseName)
+        string databaseName,
+        string? schema = null)
     {
-        return services.AddEventStoreInMemory(databaseName, typeof(TMarker).Assembly);
+        return services.AddEventStoreInMemory(databaseName, schema, new[] { typeof(TMarker).Assembly });
     }
 
     /// <summary>
@@ -198,12 +283,14 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker2">A type from the second assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="databaseName">The name of the in-memory database.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreInMemory<TMarker1, TMarker2>(
         this IServiceCollection services,
-        string databaseName)
+        string databaseName,
+        string? schema = null)
     {
-        return services.AddEventStoreInMemory(databaseName, typeof(TMarker1).Assembly, typeof(TMarker2).Assembly);
+        return services.AddEventStoreInMemory(databaseName, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly });
     }
 
     /// <summary>
@@ -214,12 +301,14 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker3">A type from the third assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="databaseName">The name of the in-memory database.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreInMemory<TMarker1, TMarker2, TMarker3>(
         this IServiceCollection services,
-        string databaseName)
+        string databaseName,
+        string? schema = null)
     {
-        return services.AddEventStoreInMemory(databaseName, typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly);
+        return services.AddEventStoreInMemory(databaseName, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly });
     }
 
     /// <summary>
@@ -242,13 +331,46 @@ public static class ServiceCollectionExtensions
         Assembly[] assemblies,
         Action<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
     {
+        return AddEventStoreSqlServer(services, connectionString, schema: null, assemblies, sqlServerOptionsAction);
+    }
+
+    /// <summary>
+    /// Adds all Event Store services using SQL Server with optional schema support.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <param name="connectionString">The connection string to use for SQL Server.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
+    /// <param name="assemblies">The assemblies to scan for attributed types. Must contain at least one assembly.</param>
+    /// <param name="sqlServerOptionsAction">An optional action to configure SQL Server specific options.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <exception cref="ArgumentException">Thrown when no assemblies are provided.</exception>
+    /// <example>
+    /// <code>
+    /// // With custom schema
+    /// services.AddEventStoreSqlServer(connectionString, schema: "orders", assemblies: new[] { typeof(OrderEvent).Assembly });
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddEventStoreSqlServer(
+        this IServiceCollection services,
+        string connectionString,
+        string? schema,
+        Assembly[] assemblies,
+        Action<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
+    {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        if (assemblies == null || assemblies.Length == 0)
+        {
+            throw new ArgumentException(
+                "At least one assembly must be provided for type metadata registration.",
+                nameof(assemblies));
+        }
 
         return services.AddEventStore(options =>
         {
             options.UseSqlServer(connectionString, sqlServerOptionsAction);
-        }, assemblies);
+        }, schema, assemblies);
     }
 
     /// <summary>
@@ -257,14 +379,16 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker">A type from the assembly to scan for attributed types.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="connectionString">The connection string to use for SQL Server.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <param name="sqlServerOptionsAction">An optional action to configure SQL Server specific options.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreSqlServer<TMarker>(
         this IServiceCollection services,
         string connectionString,
+        string? schema = null,
         Action<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
     {
-        return services.AddEventStoreSqlServer(connectionString, new[] { typeof(TMarker).Assembly }, sqlServerOptionsAction);
+        return services.AddEventStoreSqlServer(connectionString, schema, new[] { typeof(TMarker).Assembly }, sqlServerOptionsAction);
     }
 
     /// <summary>
@@ -274,14 +398,16 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker2">A type from the second assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="connectionString">The connection string to use for SQL Server.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <param name="sqlServerOptionsAction">An optional action to configure SQL Server specific options.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreSqlServer<TMarker1, TMarker2>(
         this IServiceCollection services,
         string connectionString,
+        string? schema = null,
         Action<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
     {
-        return services.AddEventStoreSqlServer(connectionString, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly }, sqlServerOptionsAction);
+        return services.AddEventStoreSqlServer(connectionString, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly }, sqlServerOptionsAction);
     }
 
     /// <summary>
@@ -292,14 +418,16 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TMarker3">A type from the third assembly to scan.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
     /// <param name="connectionString">The connection string to use for SQL Server.</param>
+    /// <param name="schema">Optional database schema name (e.g., "users", "orders"). If not provided, uses the provider's default schema.</param>
     /// <param name="sqlServerOptionsAction">An optional action to configure SQL Server specific options.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
     public static IServiceCollection AddEventStoreSqlServer<TMarker1, TMarker2, TMarker3>(
         this IServiceCollection services,
         string connectionString,
+        string? schema = null,
         Action<Microsoft.EntityFrameworkCore.Infrastructure.SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)
     {
-        return services.AddEventStoreSqlServer(connectionString, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly }, sqlServerOptionsAction);
+        return services.AddEventStoreSqlServer(connectionString, schema, new[] { typeof(TMarker1).Assembly, typeof(TMarker2).Assembly, typeof(TMarker3).Assembly }, sqlServerOptionsAction);
     }
 }
 


### PR DESCRIPTION
…cenarios

- Created EventStoreSchemaOptions record for DI schema configuration
- Updated EventStoreDbContext constructor to accept optional schema parameter
- Applied schema via HasDefaultSchema() in OnModelCreating when provided
- Added schema-aware overloads to all AddEventStore* registration methods
- Maintained backward compatibility with existing params Assembly[] signatures
- All 236 existing tests pass without modification

Enables bounded context and multi-tenant architectures to isolate event streams into separate database schemas while maintaining full backward compatibility.